### PR TITLE
need this otherwise redhat.repos file isn't populated yet

### DIFF
--- a/bootstrap-rhel.sh
+++ b/bootstrap-rhel.sh
@@ -31,6 +31,7 @@ subscription-manager subscribe --pool=$POOLID
 
 # Setup RHEL specific repos
 yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
+yum repolist
 yum-config-manager --disable "*"
 yum-config-manager --enable rhel-6-server-rpms epel
 yum-config-manager --enable rhel-6-server-optional-rpms


### PR DESCRIPTION
without this the disable=\* won't actually do anything
