### PR TITLE
switching to repo enable/disable on the yum command vs permanent

### DIFF
--- a/_repos_install.sh
+++ b/_repos_install.sh
@@ -9,7 +9,7 @@ popd
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/nightly/RHEL/6Server/x86_64/katello-repos-latest.rpm 2> /dev/null
 yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm > /dev/null
 yum -y localinstall http://yum.theforeman.org/nightly/el6/x86_64/foreman-release.rpm 2> /dev/null
-yum -y install katello
+yum -y --disablerepo=* --enablerepo=SCL,epel,foreman,foreman-plugins,katello,katello-candlepin,katello-pulp,rhel-6-server-optional-rpms,rhel-6-server-rpms install katello
 
 katello-installer -v -d
 

--- a/bootstrap-rhel.sh
+++ b/bootstrap-rhel.sh
@@ -29,13 +29,5 @@ fi
 subscription-manager register --force --username=$USERNAME --password=$PASSWORD
 subscription-manager subscribe --pool=$POOLID
 
-# Setup RHEL specific repos
-yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
-yum repolist
-yum-config-manager --disable "*"
-yum-config-manager --enable rhel-6-server-rpms epel
-yum-config-manager --enable rhel-6-server-optional-rpms
-
-
 # Do the actual install
 ./_repos_install.sh


### PR DESCRIPTION
The previous bootstrap script would disable all repos and then install
various new repos.  What this meant was that if you ran the bootstrap
script more than once (say the 1st run errored for some reason) it would
put your system in a state where it couldn't install katello on the 2nd
run.  This update moves to setting the right repos during the install
command.
