### PR TITLE
removing this line that will no longer be needed

### DIFF
--- a/_repos_install.sh
+++ b/_repos_install.sh
@@ -13,4 +13,3 @@ yum -y --disablerepo=* --enablerepo=SCL,epel,foreman,foreman-plugins,katello,kat
 
 katello-installer -v -d
 
-ip addr show eth0|grep 'inet '


### PR DESCRIPTION
We are moving to the foreman installer which spits out the installed
webui URL at the completion of the install which should be used to
get to the webui
