### PR TITLE
added rhel scl repo - required for certain ruby bits

### DIFF
--- a/bootstrap-rhel.sh
+++ b/bootstrap-rhel.sh
@@ -42,6 +42,7 @@ yum repolist
 yum-config-manager --disable "*"
 yum-config-manager --enable rhel-6-server-rpms epel
 yum-config-manager --enable rhel-6-server-optional-rpms
+yum-config-manager --enable rhel-server-rhscl-6-rpms
 
 
 # Do the actual install


### PR DESCRIPTION
I added a line to enable the rhel scl repository, which is required for some of the ruby 1.9.3 components not shipped out of the box with RHEL6.
