### PR TITLE
puppet3 support

### DIFF
--- a/_repos_install.sh
+++ b/_repos_install.sh
@@ -6,8 +6,9 @@ then
 fi
 
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/nightly/RHEL/6Server/x86_64/katello-repos-latest.rpm 2> /dev/null
-yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm > /dev/null
+yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm 2> /dev/null
 yum -y localinstall http://yum.theforeman.org/nightly/el6/x86_64/foreman-release.rpm 2> /dev/null
+yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm 2> /dev/null
 yum -y install katello
 
 if [ -d /vagrant/katello-installer ]

--- a/bootstrap-rhel.sh
+++ b/bootstrap-rhel.sh
@@ -40,7 +40,7 @@ subscription-manager subscribe --pool=$POOLID
 yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
 yum repolist
 yum-config-manager --disable "*"
-yum-config-manager --enable rhel-6-server-rpms epel
+yum-config-manager --enable rhel-6-server-rpms
 yum-config-manager --enable rhel-6-server-optional-rpms
 
 


### PR DESCRIPTION
Since the ultimate Satellite 6 product will use Puppet 3, and since the installer is now fixed, this PR will now add the upstream Puppet Labs yum repository. Installing katello will then pull in Puppet 3+ from Puppet Labs repo instead of 2.7 from EPEL.

Also there was an epel reference in the bootstrap script which I think is erroneous.
