### PR TITLE
clean up puppetlabs-release repo on reinstall as well

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -44,6 +44,7 @@ elsif ARGV.include?('centos6') || ARGV.include?('rhel6')
   system('rpm -e epel-release')
   system('rpm -e foreman-release')
   system('rpm -e katello-repos')
+  system('rpm -e puppetlabs-release')
   system('rm -f /etc/yum.repos.d/scl.repo')
 
   if ARGV.include?('rhel6')


### PR DESCRIPTION
On RHEL6 all repos get disabled and only RHEL, optional, and SCL are re-enabled. If puppetlabs-release is installed already from a previous attempt it gets disabled and never enabled again, leaving you with old puppet and puppet-server versions.
