### PR TITLE
refs #7207 - run the bootstrap_vagrant file directly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 VAGRANTFILE_API_VERSION = "2"
 
-bats_shell = "cd /vagrant && ./bats/bootstrap_vagrant.sh"
+bats_shell = "/vagrant/bats/bootstrap_vagrant.sh"
 install_shell = "yum -y install ruby && cd /vagrant && ./setup.rb "
 
 base_boxes = {


### PR DESCRIPTION
otherwise it will try to git checkout the bats git dir within /vagrant
and the directory already exists
