### PR TITLE
fixes #7980 - enable rhel7 extras repo

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -103,6 +103,7 @@ elsif ARGV.include?('centos7') || ARGV.include?('rhel7')
     system('yum repolist') # TODO: necessary?
     system('yum-config-manager --disable "*"')
     system('yum-config-manager --enable rhel-7-server-rpms epel')
+    system('yum-config-manager --enable rhel-7-server-extras-rpms')
     system('yum-config-manager --enable rhel-7-server-optional-rpms')
     system('yum-config-manager --enable rhel-server-rhscl-7-rpms')
   end


### PR DESCRIPTION
This repo is now required to pull in the dependencies needed by
python-crane (e.g. python-flask).
