### PR TITLE
Clean packages metadata when installing nightly

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -50,6 +50,9 @@ end
 # TODO: Would be nice to not require this:
 system('setenforce 0')
 
+# Make sure to clean packages metadata
+system('yum clean all')
+
 system('yum -y update nss')
 
 if ARGV.include?('fedora19')


### PR DESCRIPTION
Make sure to clean and fetch clean packages metadata to avoid package
not found install errors.
