### PR TITLE
capture installer logs on devel install

### DIFF
--- a/bats/fb-install-katello-devel.bats
+++ b/bats/fb-install-katello-devel.bats
@@ -110,6 +110,7 @@ EOF
 
 @test "collect important logs" {
   tail -n100 /home/vagrant/foreman/logs/development.log /var/log/{apache2,httpd}/*_log /var/log/foreman{-proxy,}/*log /var/log/messages /var/log/rhsm/rhsm.log > /root/last_logs || true
+  tar -czf /root/installer_logs.tar.gz /var/log/katello-installer/* || true
   foreman-debug -q -d /root/foreman-debug || true
   if tIsRedHatCompatible; then
     tPackageExists sos || tPackageInstall sos


### PR DESCRIPTION
as foreman-debug is not available, nor katello
