### PR TITLE
switching to sub-man for repo enable calls

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -88,9 +88,8 @@ elsif ['centos6', 'rhel6'].include? options[:os]
     system('yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget')
     system('yum repolist') # TODO: necessary?
     system('yum-config-manager --disable "*"')
-    system('yum-config-manager --enable rhel-6-server-rpms epel')
-    system('yum-config-manager --enable rhel-6-server-optional-rpms')
-    system('yum-config-manager --enable rhel-server-rhscl-6-rpms')
+    system('yum-config-manager --enable epel')
+    system('subscription-manager repos --enable rhel-6-server-rpms rhel-6-server-optional-rpms rhel-server-rhscl-6-rpms')
   end
 
   # NOTE: Using CentOS SCL even on RHEL to simplify subscription usage.
@@ -118,10 +117,8 @@ elsif ['rhel7', 'centos7'].include? options[:os]
     system('yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget')
     system('yum repolist') # TODO: necessary?
     system('yum-config-manager --disable "*"')
-    system('yum-config-manager --enable rhel-7-server-rpms epel')
-    system('yum-config-manager --enable rhel-7-server-extras-rpms')
-    system('yum-config-manager --enable rhel-7-server-optional-rpms')
-    system('yum-config-manager --enable rhel-server-rhscl-7-rpms')
+    system('yum-config-manager --enable epel')
+    system('subscription-manager repos --enable rhel-7-server-rpms rhel-7-server-extras-rpms rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms')
   end
 
   system('yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm')


### PR DESCRIPTION
yum-utils is occasionally unreliable when modifying Red Hat repositories

This change switches to the more reliable subscription-manager
repository modification routine and combines it into one command for a
bit better performance.
