### PR TITLE
fixes #7747 - bootstrap epel instead of fixed URL

### DIFF
--- a/bootstrap-epel.repo
+++ b/bootstrap-epel.repo
@@ -1,0 +1,6 @@
+[bootstrap-epel]
+name=Bootstrap EPEL
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgcheck=0

--- a/setup.rb
+++ b/setup.rb
@@ -70,6 +70,12 @@ system('yum -y update nss')
 
 options[:os] ||= detect_os
 
+def bootstrap_epel
+  system('cp ./bootstrap-epel.repo /etc/yum.repos.d')
+  system('yum --enablerepo=bootstrap-epel -y install epel-release')
+  system('rm -f /etc/yum.repos.d/bootstrap-epel.repo')
+end
+
 def setup_koji_repos(os)
   katello = "[katello-koji]\n" \
              "name=katello-koji\n" \
@@ -125,7 +131,7 @@ elsif ['centos6', 'rhel6'].include? options[:os]
     system('cp ./scl.repo /etc/yum.repos.d/')
   end
 
-  system('yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm')
+  bootstrap_epel
   system('yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm')
   system("yum -y localinstall http://yum.theforeman.org/#{foreman_version[options[:version]]}/el6/x86_64/foreman-release.rpm")
 
@@ -154,9 +160,9 @@ elsif ['rhel7', 'centos7'].include? options[:os]
     system('subscription-manager repos --enable rhel-7-server-rpms --enable rhel-7-server-extras-rpms --enable rhel-7-server-optional-rpms --enable rhel-server-rhscl-7-rpms')
   end
 
+  bootstrap_epel
   system('yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm')
   system('yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm')
-  system('yum -y localinstall http://download-i2.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm')
   system('yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm')
   system("yum -y localinstall http://yum.theforeman.org/#{foreman_version[options[:version]]}/el7/x86_64/foreman-release.rpm")
 


### PR DESCRIPTION
Based on http://stackoverflow.com/questions/14016286/how-to-programmatically-install-the-latest-epel-release-rpm-without-knowing-its
