### PR TITLE
Override the default RHEL releasever

### DIFF
--- a/bootstrap-epel.repo
+++ b/bootstrap-epel.repo
@@ -1,6 +1,0 @@
-[bootstrap-epel]
-name=Bootstrap EPEL
-mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgcheck=0


### PR DESCRIPTION
RHEL versions default releasever includes the minor versions or
6Server or 7Server. we need to override this to get epel-release
installed.
