### PR TITLE
Explicitly use python 2 for vagrant.py

### DIFF
--- a/playbooks/inventory/vagrant.py
+++ b/playbooks/inventory/vagrant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Adapted from Mark Mandel's implementation
 # https://github.com/ansible/ansible/blob/devel/plugins/inventory/vagrant.py
 import argparse


### PR DESCRIPTION
vagrant.py is python 2 only. This breaks systems where /usr/bin/python
is version 3.