### PR TITLE
Set up git forks; allow configurable server

### DIFF
--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -7,6 +7,16 @@ centos7-devel:
     variables:
       katello_devel_github_username: <REPLACE ME>
 
+centos7-hammer-devel:
+  box: centos7
+  memory: 512
+  ansible:
+    playbook: 'playbooks/hammer_devel.yml'
+    group: 'hammer-devel'
+    variables:
+      hammer_devel_github_username: '<REPLACE ME>'
+      hammer_devel_github_fork_remote_name: 'origin'
+
 katello-remote-execution:
   box: centos7-katello-nightly
   installer: --enable-foreman-remote-execution

--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -101,10 +101,3 @@ boxes:
   pipeline-proxy-3.3-centos7:
     box: centos7
     memory: 3072
-
-  centos7-hammer-devel:
-    box: centos7
-    memory: 512
-    ansible:
-      playbook: 'playbooks/hammer_devel.yml'
-      group: 'hammer_devel'

--- a/docs/development.md
+++ b/docs/development.md
@@ -138,16 +138,16 @@ such as [Foreman Tasks](https://github.com/theforeman/hammer-cli-foreman-tasks) 
 importing/exporting data via [CSV](https://github.com/Katello/hammer-cli-csv).
 The CLI can be configured to work with any version of Foreman. To facilitate
 development in Hammer or any of its plugins, a lightweight vagrant box is
-provided in this repository:
+provided in the `boxes.yaml.example` file. To use this functionality, copy the
+centos7-hammer-devel configuration from the example file into your `boxes.yaml`
+file, changing options as necessary. Then run the following:
 
 ```sh
 vagrant up centos7-hammer-devel
 ```
 
 In the vagrant box, find the Hammer repositories at `/home/vagrant/` and the
-configuration at `/home/vagrant/.hammer`. Specifically, to change the Foreman
-instance Hammer points to, update
-`/home/vagrant/.hammer/cli.modules.d/foreman.yml`.
+configuration at `/home/vagrant/.hammer`.
 
 ## Capsule Development
 

--- a/playbooks/roles/hammer_devel/defaults/main.yml
+++ b/playbooks/roles/hammer_devel/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 hammer_devel_ruby_version: 2.3.1
-hammer_devel_host: http://centos7-devel.example.com:3000
+hammer_devel_server_group: "server-{{ inventory_hostname }}"
+hammer_devel_server: "centos7-devel"
+hammer_devel_server_protocol: 'https'
+hammer_devel_server_port: 443
+hammer_devel_host: "{{ hammer_devel_server_protocol }}://{{ hammer_devel_server }}:{{ hammer_devel_server_port }}"
 hammer_devel_username: admin
 hammer_devel_password: changeme
 hammer_devel_repositories:

--- a/playbooks/roles/hammer_devel/tasks/hammer_install.yml
+++ b/playbooks/roles/hammer_devel/tasks/hammer_install.yml
@@ -7,6 +7,21 @@
     remote: upstream
   with_items: "{{ hammer_devel_repositories }}"
 
+- name: 'Check if the fork remotes exist'
+  shell: "git remote | grep ^{{ hammer_devel_github_fork_remote_name }}$"
+  args:
+    chdir: ~/{{ item.split('/')[1] }}
+  ignore_errors: yes
+  with_items: "{{ hammer_devel_repositories }}"
+  register: fork_remotes_exist
+
+- name: 'Add fork remotes to cloned repositories'
+  command: "git remote add {{ hammer_devel_github_fork_remote_name }} git@github.com:{{ hammer_devel_github_username }}/{{ item.item.split('/')[1] }}.git"
+  when: item.rc != 0
+  args:
+    chdir: ~/{{ item.item.split('/')[1] }}
+  with_items: "{{ fork_remotes_exist.results }}"
+
 - name: 'Add local gems to Gemfile.local'
   blockinfile:
     dest: ~/hammer-cli-katello/Gemfile.local


### PR DESCRIPTION
- Set up the user's GitHub forks in each hammer repository
- Allow users to configure the Katello server hostname and port before
provisioning