### PR TITLE
Support issuing additional certificates

### DIFF
--- a/roles/custom_certificates/tasks/issue.yml
+++ b/roles/custom_certificates/tasks/issue.yml
@@ -1,0 +1,23 @@
+---
+- name: 'Creating signing request'
+  command: >
+    openssl req -new
+      -newkey rsa:2048
+      -nodes
+      -out    "{{ custom_certificates_ca_directory_requests }}/{{ custom_certificates_hostname }}.csr"
+      -keyout "{{ custom_certificates_ca_directory_keys }}/{{ custom_certificates_hostname }}.key"
+      -subj "/C=US/ST=North Carolina/L=Raleigh/O=Foreman/OU=Katello/CN={{ custom_certificates_hostname }}"
+  args:
+    creates: "{{ custom_certificates_ca_directory_requests }}/{{ custom_certificates_hostname }}.csr"
+
+- name: 'Sign signing request'
+  command: >
+      openssl ca
+        -config "{{ custom_certificates_ca_directory }}/openssl.cnf"
+        -batch
+        -policy signing_policy
+        -extensions signing_req
+        -out "{{ custom_certificates_ca_directory_certs }}/{{ custom_certificates_hostname }}.crt"
+        -infiles "{{ custom_certificates_ca_directory_requests }}/{{ custom_certificates_hostname }}.csr"
+  args:
+      creates: "{{ custom_certificates_ca_directory_certs }}/{{ custom_certificates_hostname }}.crt"

--- a/roles/custom_certificates/tasks/main.yml
+++ b/roles/custom_certificates/tasks/main.yml
@@ -87,3 +87,9 @@
       -out "{{ custom_certificates_ca_directory_certs }}/{{ custom_certificates_server }}.crt"
   args:
     creates: "{{ custom_certificates_ca_directory_certs }}/{{ custom_certificates_server }}.crt"
+
+- include: issue.yml
+  when: custom_certificates_hostnames is defined
+  with_items: "{{ custom_certificates_hostnames }}"
+  loop_control:
+    loop_var: custom_certificates_hostname

--- a/roles/custom_certificates/templates/openssl.cnf.j2
+++ b/roles/custom_certificates/templates/openssl.cnf.j2
@@ -75,3 +75,16 @@ nsCertType              = client
 keyUsage                = digitalSignature, keyEncipherment
 extendedKeyUsage        = clientAuth
 nsComment               = "OpenSSL Certificate for SSL Client"
+
+[ signing_policy ]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ signing_req ]
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid,issuer


### PR DESCRIPTION
Creates the CA, and then issues an additional certificate.  Can be called multiple times to issue multiple certificates.

Usage:

    ansible-playbook -l hostname playbooks/custom_certificates.yml -e "custom_certificates_hostname=additional-hostname.example.com"