### PR TITLE
Fixing issue with disabling ipv6 while pulp is running

### DIFF
--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -22,10 +22,6 @@ setup() {
     fi
   fi
 
-  #disable ipv6 for issue #12386
-  sysctl -w net.ipv6.conf.default.disable_ipv6=1
-  sysctl -w net.ipv6.conf.all.disable_ipv6=1
-
   tPackageExists curl || tPackageInstall curl
   if tIsRedHatCompatible; then
     tPackageExists yum-utils || tPackageInstall yum-utils

--- a/pipelines/pipeline_katello_nightly.yml
+++ b/pipelines/pipeline_katello_nightly.yml
@@ -26,6 +26,7 @@
   roles:
     - selinux
     - etc_hosts
+    - disable_ipv6
     - epel_repositories
     - puppet_repositories
     - foreman_repositories

--- a/playbooks/bats_pipeline_nightly.yml
+++ b/playbooks/bats_pipeline_nightly.yml
@@ -10,6 +10,7 @@
   roles:
     - selinux
     - etc_hosts
+    - disable_ipv6
     - epel_repositories
     - puppet_repositories
     - foreman_repositories

--- a/playbooks/roles/disable_ipv6/tasks/main.yml
+++ b/playbooks/roles/disable_ipv6/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# disable ipv6 for issue #12386. qdrouterd only listens on ipv4.
+# also, do this before running katello installer so we don't interfere with
+# pulp (see https://pulp.plan.io/issues/2586)
+- name: "Disable ipv6"
+  shell: |
+    sysctl -w net.ipv6.conf.default.disable_ipv6=1
+    sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
+- name: "Update hosts file"
+  shell: "sed -i 's/^[[:space:]]*::/#::/' /etc/hosts"


### PR DESCRIPTION
We're seeing workers die because they can't connect to qpid. Seems to be
caused by disabling ipv6 while pulp is running. Making a change to
disable ipv6 before pulp is installed.

More information: https://pulp.plan.io/issues/2586#note-5