### PR TITLE
Limit rsync to files less than 100m

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,7 +92,7 @@ module Forklift
 
       machine.vm.provider :libvirt do |p, override|
         override.vm.box_url = box.fetch('libvirt') if box.fetch('libvirt', false)
-        override.vm.synced_folder ".", "/vagrant", type: "rsync"
+        override.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__args: ["--max-size=100m"]
         override.vm.network :public_network, :dev => box.fetch('bridged'), :mode => 'bridge' if box.fetch('bridged', false)
         networks.each do |network|
           override.vm.network network['type'], network['options']


### PR DESCRIPTION
I have some packer work in my forklift directory, and I was trying
to figure out why my rsync was taking so long. This changes it
to limit it to 100 megs.