### PR TITLE
Adds mention of vagrant libvirt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Forklift provides tools to create Foreman/Katello environments for development, 
 
 * Vagrant - 1.8+ - Both the VirtualBox and Libvirt providers are tested
 * Ansible - 2.1+
+* [Vagrant Libvirt provider plugin](https://github.com/vagrant-libvirt/vagrant-libvirt) (if using Libvirt) 
 
 ### Quickstart
 


### PR DESCRIPTION
Its not obvious to vagrant noobs that you need a libvirt provider. Seeing as a fair amount of forklift users are using libvirt, I added a mention of it in the Requirements