### PR TITLE
Add Debian support

### DIFF
--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -3,6 +3,18 @@ shells:
     shell: '/vagrant/shells/runcible.sh'
 
 boxes:
+  debian8:
+    box_name:   'debian/jessie64'
+    image_name: !ruby/regexp '/Debian.*Jessie/'
+    default:    true
+    pty:        true
+
+  debian9:
+    box_name:   'debian/stretch64'
+    image_name: !ruby/regexp '/Debian.*Stretch/'
+    default:    true
+    pty:        true
+
   centos6:
     box_name:   'centos/6'
     image_name: !ruby/regexp '/CentOS 6.*PV/'

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -24,15 +24,19 @@ installers:
     puppet: 4
     boxes:
       - 'centos7'
+      - 'debian8'
 
   - foreman: '1.15'
     katello: '3.4'
     puppet: 4
     boxes:
       - 'centos7'
+      - 'debian8'
 
   - foreman: 'nightly'
     katello: 'nightly'
     puppet: 4
     boxes:
       - 'centos7'
+      - 'debian8'
+      - 'debian9'

--- a/roles/epel_repositories/tasks/main.yml
+++ b/roles/epel_repositories/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 - name: 'Setup Epel Repository'
-  yum: name=http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm state=present
+  yum:
+    name: http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: present
   tags:
     - packages
+  when: ansible_os_family == 'RedHat'

--- a/roles/foreman_installer/tasks/locales.yml
+++ b/roles/foreman_installer/tasks/locales.yml
@@ -1,0 +1,17 @@
+---
+- name: 'Install locales'
+  package:
+    name: locales
+    state: latest
+
+- name: 'Ensure en_US.UTF-8 locale is available'
+  locale_gen:
+    name: en_US.UTF-8
+
+- name: configure /etc/default/locale
+  copy:
+    dest: /etc/default/locale
+    content: |
+      LC_ALL="en_US.UTF-8"
+      LANG="en_US.UTF-8"
+      LANGUAGE="en_US.UTF-8"

--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - include: packages.yml
 
+- include: locales.yml
+  when: ansible_os_family == 'Debian'
+
 - include: module_pr.yml
   when: foreman_installer_module_prs != ""
 

--- a/roles/foreman_installer/tasks/packages.yml
+++ b/roles/foreman_installer/tasks/packages.yml
@@ -1,13 +1,13 @@
 ---
 - name: 'Install foreman-installer'
-  yum:
+  package:
     name: foreman-installer
     state: latest
   tags:
     - packages
 
 - name: 'Install additional packages'
-  yum:
+  package:
     name: "{{ item }}"
     state: latest
   with_items: "{{ foreman_installer_additional_packages }}"

--- a/roles/foreman_repositories/tasks/debian_release_repos.yml
+++ b/roles/foreman_repositories/tasks/debian_release_repos.yml
@@ -1,0 +1,14 @@
+---
+- name: 'Install Foreman GPG key'
+  apt_key:
+    url: https://deb.theforeman.org/foreman.asc
+
+- name: 'Install Foreman repository'
+  apt_repository:
+    repo: deb http://deb.theforeman.org {{ ansible_distribution_release }} {{ foreman_repositories_version }}
+    state: present
+
+- name: 'Install Foreman plugins repository'
+  apt_repository:
+    repo: deb http://deb.theforeman.org plugins {{ foreman_repositories_version }}
+    state: present

--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
-- include: release_repos.yml
-  when: foreman_repositories_use_release and not foreman_repositories_use_koji
+- include: debian_release_repos.yml
+  when: ansible_os_family == 'Debian' and foreman_repositories_use_release
+
+- include: redhat_release_repos.yml
+  when: ansible_os_family == 'RedHat' and foreman_repositories_use_release and not foreman_repositories_use_koji
 
 - include: koji_repos.yml
   when: foreman_repositories_use_koji
@@ -11,3 +14,4 @@
     state: latest
   tags:
     - packages
+  when: ansible_os_family == 'RedHat'

--- a/roles/foreman_repositories/tasks/redhat_release_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_release_repos.yml
@@ -3,14 +3,14 @@
   yum:
     name: http://yum.theforeman.org/{{ "releases/" if foreman_repositories_version != 'nightly' else '' }}{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
     state: present
-  when: foreman_repositories_version != 1.13 or ansible_distribution_major_version != "6"
   tags:
     - packages
+  when: foreman_repositories_version != 1.13 or ansible_distribution_major_version != "6"
 
 - name: 'Setup Foreman Repository'
   yum:
     name: http://fedorapeople.org/groups/katello/releases/yum/foreman/1.13/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
     state: present
-  when: foreman_repositories_version == 1.13 and ansible_distribution_major_version == "6"
   tags:
     - packages
+  when: foreman_repositories_version == 1.13 and ansible_distribution_major_version == "6"

--- a/roles/puppet_repositories/tasks/puppetlabs-4-debian.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-4-debian.yml
@@ -1,0 +1,12 @@
+---
+- name: 'Install Puppetlabs GPG key'
+  apt_key:
+    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+  # Puppetlabs has no repositories for stretch
+  when: ansible_distribution_release != 'stretch'
+
+- name: 'Install Puppetlabs PC1 repository'
+  apt_repository:
+    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} PC1
+    state: present
+  when: ansible_distribution_release != 'stretch'

--- a/roles/selinux/tasks/main.yml
+++ b/roles/selinux/tasks/main.yml
@@ -5,6 +5,7 @@
     state: installed
   tags:
     - env_setup
+  when: ansible_os_family == 'RedHat'
 
 - name: 'Set selinux state'
   selinux:
@@ -12,3 +13,4 @@
     state: "{{ selinux_state }}"
   tags:
     - env_setup
+  when: ansible_os_family == 'RedHat'

--- a/roles/update_os_packages/tasks/main.yml
+++ b/roles/update_os_packages/tasks/main.yml
@@ -1,8 +1,17 @@
 ---
-- name: 'Update packages'
+- name: 'RedHat | Update packages'
   yum:
     name: '*'
     update_cache: yes
     state: latest
   tags:
     - packages
+  when: ansible_os_family == 'RedHat'
+
+- name: 'Debian | Update packages'
+  apt:
+    upgrade: dist
+    update_cache: yes
+  tags:
+    - packages
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This allows you to provision a Foreman 1.14 install on Debian. There are
still many corners that problably don't support it and Katello boxes are
also generated but it's a start.