### PR TITLE
Fixes #421 - Add option to set folders to sync into the box

### DIFF
--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -72,6 +72,7 @@ module Forklift
         configure_libvirt(machine, box, networks)
         configure_virtualbox(machine, box)
         configure_rackspace(machine, box)
+        configure_synced_folders(machine, box)
 
         yield machine if block_given?
       end
@@ -97,8 +98,7 @@ module Forklift
     def configure_networks(networks)
       return [] if networks.empty?
       networks.map do |network|
-        symbolized_options = network['options'].inject({}) { |memo, (k, v)| memo.update(k.to_sym => v) }
-        network.update('options' => symbolized_options)
+        network.update('options' => symbolized_options(network['options']))
       end
     end
 
@@ -132,6 +132,28 @@ module Forklift
         shell.inline = box.fetch('shell')
         shell.privileged = false if box.key?('privileged')
       end
+    end
+
+    # Configures synced folders defined for the box
+    # and the private network required for them
+    def configure_synced_folders(machine, box)
+      configure_private_network(machine, box)
+
+      box.fetch('synced_folders', []).each do |folder|
+        machine.vm.synced_folder folder['path'], folder['mount_point'], symbolized_options(folder['options'])
+      end
+    end
+
+    def configure_private_network(machine, box)
+      ip = box.fetch('private_ip', nil)
+      options = {}.tap do |hash|
+        if ip
+          hash[:ip] = ip
+        else
+          hash[:type] = 'dhcp'
+        end
+      end
+      machine.vm.network :private_network, options
     end
 
     def configure_libvirt(machine, box, networks = [])
@@ -180,6 +202,12 @@ module Forklift
         p.image          = box.fetch('image_name')
         override.ssh.pty = true if box.fetch('pty')
       end
+    end
+
+    private
+
+    def symbolized_options(hash)
+      hash.inject({}) { |memo, (k, v)| memo.update(k.to_sym => v) }
     end
 
   end

--- a/lib/forklift/box_factory.rb
+++ b/lib/forklift/box_factory.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'erb'
 require 'yaml'
 
 module Forklift
@@ -12,7 +13,7 @@ module Forklift
     end
 
     def add_boxes(box_file, version_file)
-      config = YAML.load_file(box_file)
+      config = load_box_file(box_file)
       return @boxes unless config
 
       versions = YAML.load_file(version_file)
@@ -30,6 +31,11 @@ module Forklift
     end
 
     private
+
+    def load_box_file(file)
+      file = File.read(file)
+      YAML.safe_load(ERB.new(file).result, [Regexp], [], true)
+    end
 
     def process_shells(shells)
       @shells.merge!(shells)


### PR DESCRIPTION
This adds the necessary configuration for vagrant to enable
defining synced folders in `boxes.yaml` in the following form:

```
centos7-devel:
  box: centos7
  private_ip: "172.28.128.15"
  synced_folders:
    - mount_point: '/syncs/foreman'
      path: <%= "#{ENV['HOME']}/RedHat/Foreman/Repos/foreman" %>
      options:
        type: 'nfs'
        nfs_udp: false
```

Since `nfs` requires a private network, this can now be also configured easily via `private_ip`.
`options` are simply passed through to allow using any available adapter. I've only tested `nfs` so far, but `rsync` and `sshfs` should work as well.