### PR TITLE
allow setting provider specific options in the boxes yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ disk_size -- specify the size (in gigabytes) of the box's virtual disk. This
              resize partitions and filesystems manually.
 ansible -- updates the Ansible provisioner configuration including the
            playbook to be ran or any variables to set
+libvirt_options -- sets Libvirt specific options
+virtualbox_options -- sets VirtualBox specific options
+rackspace_options -- sets Rackspace specific options
 ```
 
 Entirely new boxes can be created that do not orginate from a box defined within the Vagrantfile. For example, if you had access to a RHEL Vagrant box:
@@ -112,6 +115,15 @@ static:
         libvirt__iface_name: vnet2
 ```
 
+Example with custom libvirt management network:
+
+```
+static:
+  box: centos7
+  hostname: mystatic.box.com
+  libvirt_options:
+    management_network_address: 172.23.99.0/24
+```
 ### Customize Deployment Settings
 
 Some settings can be customized for the entirety of the deployment, they are:

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -179,6 +179,10 @@ module Forklift
         p.cpus = box.fetch('cpus') if box.fetch('cpus', false)
         p.memory = box.fetch('memory') if box.fetch('memory', false)
         p.machine_virtual_size = box.fetch('disk_size') if box.fetch('disk_size', false)
+
+        box.fetch('libvirt_options', []).each do |opt, val|
+          p.instance_variable_set("@#{opt}", val)
+        end
       end
     end
 
@@ -199,6 +203,10 @@ module Forklift
           override.vm.network :forwarded_port, guest: 80, host: 8080
           override.vm.network :forwarded_port, guest: 443, host: 4433
         end
+
+        box.fetch('virtualbox_options', []).each do |opt, val|
+          p.instance_variable_set("@#{opt}", val)
+        end
       end
     end
 
@@ -210,6 +218,10 @@ module Forklift
         p.flavor         = /4GB/
         p.image          = box.fetch('image_name')
         override.ssh.pty = true if box.fetch('pty')
+
+        box.fetch('rackspace_options', []).each do |opt, val|
+          p.instance_variable_set("@#{opt}", val)
+        end
       end
     end
 


### PR DESCRIPTION
this allows to pass arbitrary options to the providers, which can be used to set options that are not exposed via a specific named parameter.

examples are cpu-mode, management_network_* etc.