### PR TITLE
Make puppet 4 the default version

### DIFF
--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -28,8 +28,6 @@ boxes:
           - 'playbooks/katello.yml'
           - 'playbooks/katello_provisioning.yml'
       group: 'server'
-      variables:
-        puppet_repositories_version: 4
 
   centos7-freeipa-server:
       box: centos7

--- a/playbooks/roles/puppet_repositories/defaults/main.yml
+++ b/playbooks/roles/puppet_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-puppet_repositories_version: 3
+puppet_repositories_version: 4


### PR DESCRIPTION
Make puppet 4 the default for all new installs.  This may cause issues with BATS, we might have to up the memory of the rackspace box, or perhaps decrease JVM heap size (see https://docs.puppet.com/puppetserver/latest/tuning_guide.html#jvm-heap-size)