### PR TITLE
Refactor foreman_installer role

### DIFF
--- a/playbooks/roles/foreman_installer/defaults/main.yml
+++ b/playbooks/roles/foreman_installer/defaults/main.yml
@@ -5,6 +5,7 @@ foreman_installer_skip_installer: False
 foreman_installer_verbose: True
 foreman_installer_scenario: foreman
 foreman_installer_upgrade: False
+foreman_installer_command: foreman-installer
 
 # Comma-separated list of "organization/module/pr_number", e.g. "katello/foreman_proxy_content/37,katello/certs/34"
 foreman_installer_module_prs: ""

--- a/playbooks/roles/foreman_installer/tasks/install.yml
+++ b/playbooks/roles/foreman_installer/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Run installer'
   shell: >
-      foreman-installer {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
+      {{ foreman_installer_command }} {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
       --scenario "{{ foreman_installer_scenario }}"
       {{ foreman_installer_options }}
       {{ foreman_installer_options_internal_use_only | join(" ") }}

--- a/playbooks/roles/foreman_installer/tasks/packages.yml
+++ b/playbooks/roles/foreman_installer/tasks/packages.yml
@@ -5,11 +5,6 @@
     update_cache: yes
     state: latest
 
-- name: 'Install foreman-release-scl'
-  yum:
-    name: foreman-release-scl
-    state: latest
-
 - name: 'Install foreman-installer'
   yum:
     name: foreman-installer

--- a/playbooks/roles/foreman_installer/tasks/upgrade.yml
+++ b/playbooks/roles/foreman_installer/tasks/upgrade.yml
@@ -13,7 +13,7 @@
 
 - name: 'Run installer upgrade'
   command: >
-    foreman-installer {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
+    {{ foreman_installer_command }} {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
     --disable-system-checks
     --upgrade
     --scenario "{{ foreman_installer_scenario }}"

--- a/playbooks/roles/foreman_repositories/tasks/release_repos.yml
+++ b/playbooks/roles/foreman_repositories/tasks/release_repos.yml
@@ -10,3 +10,8 @@
     name: http://fedorapeople.org/groups/katello/releases/yum/foreman/1.13/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
     state: present
   when: foreman_repositories_version == 1.13 and ansible_distribution_major_version == "6"
+
+- name: 'Install foreman-release-scl'
+  yum:
+    name: foreman-release-scl
+    state: latest


### PR DESCRIPTION
I'd like to be able to re-use the forklift roles for Satellite, and Satellite distributes a branded installer.
