### PR TITLE
Dont break ansible provisions if a box doesnt have group defined

### DIFF
--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -111,13 +111,16 @@ module Forklift
 
     def configure_ansible(machine, ansible, box_name)
       return unless ansible
-      unless @ansible_groups[ansible['group'].to_s]
-        @ansible_groups[ansible['group'].to_s] = []
+
+      if ansible.key?('group') || !ansible['group'].nil?
+        unless @ansible_groups[ansible['group'].to_s]
+          @ansible_groups[ansible['group'].to_s] = []
+        end
+
+        @ansible_groups[ansible['group'].to_s] << box_name
       end
 
-      @ansible_groups[ansible['group'].to_s] << box_name
-
-      if ansible.key?('server')
+      if ansible.key?('server') || !ansible['server'].nil?
         @ansible_groups["server-#{box_name}"] = ansible['server']
       end
 


### PR DESCRIPTION
to test, add this into boxes.yaml and it will break all ansible provisioning by creating an unnamed group in `.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory`

```yaml
test:
  box: centos7
  ansible:
    playbook: 'playbooks/katello_client.yml'
    server: 'centos7-katello-3-2'
```