### PR TITLE
make bats role more flexible

### DIFF
--- a/playbooks/roles/bats/defaults/main.yaml
+++ b/playbooks/roles/bats/defaults/main.yaml
@@ -1,6 +1,7 @@
 ---
 bats_git_dir: "/root/bats"
 bats_forklift_dir: "/root/forklift"
+bats_forklift_repo: "https://github.com/theforeman/forklift.git"
 bats_output_dir: "/root/bats_results"
 bats_update_forklift: "yes"
 bats_tests:

--- a/playbooks/roles/bats/defaults/main.yaml
+++ b/playbooks/roles/bats/defaults/main.yaml
@@ -2,6 +2,7 @@
 bats_git_dir: "/root/bats"
 bats_forklift_dir: "/root/forklift"
 bats_forklift_repo: "https://github.com/theforeman/forklift.git"
+bats_forklift_version: HEAD
 bats_output_dir: "/root/bats_results"
 bats_update_forklift: "yes"
 bats_tests:

--- a/playbooks/roles/bats/tasks/main.yml
+++ b/playbooks/roles/bats/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: "Clone forklift"
   git:
-    repo: "https://github.com/katello/forklift.git"
+    repo: "{{ bats_forklift_repo }}"
     dest: "{{ bats_forklift_dir }}"
     update: "{{ bats_update_forklift }}"
 

--- a/playbooks/roles/bats/tasks/main.yml
+++ b/playbooks/roles/bats/tasks/main.yml
@@ -25,6 +25,7 @@
     repo: "{{ bats_forklift_repo }}"
     dest: "{{ bats_forklift_dir }}"
     update: "{{ bats_update_forklift }}"
+    version: "{{ bats_forklift_version }}"
 
 - name: "Bats output directory"
   file:


### PR DESCRIPTION
this allows to run bats from either a completely different repository (a fork) or/and a different branch.