### PR TITLE
Increase default RAM to 6gbs

### DIFF
--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -23,7 +23,7 @@ module Forklift
       overrides = {}
       settings_file = "#{File.dirname(__FILE__)}/../../settings.yaml"
       default_settings = {
-        'memory' => 4608,
+        'memory' => 6144,
         'cpus' => 2,
         'sync_type' => 'rsync',
         'cachier' => {


### PR DESCRIPTION
With puppet 4, katello is more resource intensive and we should
default to a higher amount of RAM to avoid OOM errors. This can
always be overridden with `memory:` option in boxes.yaml