### PR TITLE
run fb-proxy.bats on the katello box

### DIFF
--- a/bats/fb-proxy.bats
+++ b/bats/fb-proxy.bats
@@ -9,7 +9,6 @@ load fixtures/content
 
 setup() {
   tSetOSVersion
-  tPackageExists foreman-cli || tPackageInstall foreman-cli
   PROXY_INFO=$(hammer --output json proxy list --search "feature = \"Pulp Node\"")
   PROXY_ID=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read).first['Id']")
   PROXY_HOSTNAME=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read).first['Name']")

--- a/pipelines/pipeline_katello_30.yml
+++ b/pipelines/pipeline_katello_30.yml
@@ -67,14 +67,12 @@
     - foreman_installer
 
 - hosts: pipeline-katello-3.0-centos7
-  become: true
-  roles:
-    - bats
-
-- hosts: pipeline-capsule-3.0-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_31.yml
+++ b/pipelines/pipeline_katello_31.yml
@@ -65,13 +65,12 @@
 
 - hosts: pipeline-katello-3.1-centos7
   become: true
-  roles:
-    - bats
-
-- hosts: pipeline-capsule-3.1-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_31_to_33_upgrade.yml
+++ b/pipelines/pipeline_katello_31_to_33_upgrade.yml
@@ -75,13 +75,12 @@
 
 - hosts: pipeline-katello-3.1-3.3-centos7
   become: true
-  roles:
-    - bats
-
-- hosts: pipeline-proxy-3.1-3.3-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_32.yml
+++ b/pipelines/pipeline_katello_32.yml
@@ -68,13 +68,12 @@
 
 - hosts: pipeline-katello-3.2-centos7
   become: true
-  roles:
-    - bats
-
-- hosts: pipeline-proxy-3.2-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_33.yml
+++ b/pipelines/pipeline_katello_33.yml
@@ -70,13 +70,12 @@
 
 - hosts: pipeline-katello-3.3-centos7
   become: true
-  roles:
-    - bats
-
-- hosts: pipeline-proxy-3.3-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_nightly.yml
+++ b/pipelines/pipeline_katello_nightly.yml
@@ -69,13 +69,12 @@
 
 - hosts: pipeline-katello-nightly-centos7
   become: true
-  roles:
-    - bats
-
-- hosts: pipeline-proxy-nightly-centos7
-  become: true
   vars:
     bats_tests:
+      - fb-test-katello.bats
+      - fb-content-katello.bats
       - fb-proxy.bats
+      - fb-destroy-organization.bats
+      - fb-finish-katello.bats
   roles:
     - bats


### PR DESCRIPTION
fb-proxy.bats needs working org setup and actual content to work.
and it also needs working hammer. all that is present on the katello box
during the bats run, but not afterwards. so lets just run fb-proxy.bats
also during the bats run on the katello box.

not including it into the default tests as it needs an additional box to
be set up, which we do not have during *all* runs.