### PR TITLE
swapfile: don't calculate checksum or md5sum of the file

### DIFF
--- a/playbooks/roles/swapfile/tasks/main.yml
+++ b/playbooks/roles/swapfile/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: check if swap file exists
   stat:
     path: "{{ swapfile_path }}"
+    get_checksum: False
+    get_md5: False
   register: swapfile_check
 
 - name: create swap file {{ swapfile_path }}


### PR DESCRIPTION
this gives quite an performance boost on bigger files like our swapfile

poor mans benchmark on my laptop:

    stat -------------------------------------------- 6.71s
    get_md5=False ----------------------------------- 3.49s
    get_checksum=False ------------------------------ 3.25s
    get_checksum=False get_md5=False ---------------- 0.22s