### PR TITLE
try different URLs to get the package from the proxy

### DIFF
--- a/bats/fb-proxy.bats
+++ b/bats/fb-proxy.bats
@@ -27,6 +27,8 @@ setup() {
 }
 
 @test "content is available from proxy" {
-  wget http://$PROXY_HOSTNAME/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm -P /tmp
+  URL1="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
+  URL2="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
+  wget $URL1 -P /tmp || wget $URL2 -P /tmp
   tFileExists /tmp/walrus-0.71-1.noarch.rpm && tNonZeroFile /tmp/walrus-0.71-1.noarch.rpm
 }


### PR DESCRIPTION
depending on the config, pulp will sometimes put packages directly in
the repo folder, and sometimes into Packages/<first_letter>.
as we are not actually reading the repodata, lets try both URLs