### PR TITLE
be more verbose in the register subscription manager bats test

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -127,8 +127,14 @@ EOF
   fi
 
   run yum erase -y 'katello-ca-consumer-*'
+  echo "rc=${status}"
+  echo "${output}"
   run rpm -Uvh http://localhost/pub/katello-ca-consumer-latest.noarch.rpm
+  echo "rc=${status}"
+  echo "${output}"
   run subscription-manager register --force --org="${ORGANIZATION_LABEL}" --activationkey="${ACTIVATION_KEY}"
+  echo "rc=${status}"
+  echo "${output}"
   subscription-manager list --consumed | grep "${PRODUCT}"
 }
 


### PR DESCRIPTION
we use `run` a lot, because we want to ignore the exit code, but we are
still interested in the command output to understand what exactly broke
when the last step fails.