### PR TITLE
 Remove org_id from katello client playbook

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -210,7 +210,6 @@ awesome-client:
     playbook: 'playbooks/katello_client.yml'
     variables:
       katello_client_server: 'your-katello-server-name'
-      katello_client_organization: 'Default_Organization'
       katello_client_environment: 'Library'
       katello_client_username: 'admin'
       katello_client_password: 'changeme'

--- a/roles/katello_client/defaults/main.yml
+++ b/roles/katello_client/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-katello_client_organization: "Default_Organization"
 katello_client_environment: "Library"
 katello_client_username: "admin"
 katello_client_password: "changeme"

--- a/roles/katello_client/tasks/main.yml
+++ b/roles/katello_client/tasks/main.yml
@@ -7,7 +7,6 @@
 - name: 'Register client with subscription-manager'
   redhat_subscription:
     state: "present"
-    org_id: "{{ katello_client_organization }}"
     environment: "{{ katello_client_environment }}"
     username: "{{ katello_client_username }}"
     password: "{{ katello_client_password }}"


### PR DESCRIPTION
org_id isn't necessary and is throwing an error since it needs to
have activation_key_id as well.