### PR TITLE
drop default_ prefix from settings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ static:
 
 Some settings can be customized for the entirety of the deployment, they are:
 
- * default_memory: Memory to give boxes by default unless specified by a box
- * default_cpus: Number of CPUs to give boxes by default unless specified by a box
+ * memory: Memory to give boxes by default unless specified by a box
+ * cpus: Number of CPUs to give boxes by default unless specified by a box
  * sync_type: type of sync to use for transfer to the Vagrant box
  * mount_options: options for the vagrant-cachier plugin
 

--- a/settings.yaml.example
+++ b/settings.yaml.example
@@ -1,6 +1,6 @@
 ---
-default_memory: 4608
-default_cpus: 2
+memory: 4608
+cpus: 2
 sync_type: 'rsync'
 
 cachier:


### PR DESCRIPTION
otherwise noone will use them