### PR TITLE
Sleep for a minute before testing ping

### DIFF
--- a/bats/fb-test-katello.bats
+++ b/bats/fb-test-katello.bats
@@ -4,7 +4,10 @@
 set -o pipefail
 
 @test "check hammer ping" {
-  hammer ping
+  local next_wait_time=0
+  until hammer ping || [ $next_wait_time -eq 12 ]; do
+     sleep $(( next_wait_time++ ))
+  done
 }
 
 @test "check katello-service status" {


### PR DESCRIPTION
Sometimes foreman-tasks has not fully started by the time ping runs so lets sleep for a bit before checking the ping.