### PR TITLE
Improvements to bats/Debian support

### DIFF
--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -11,6 +11,12 @@
     - git
     - sos
 
+- name: "Install bats from package"
+  package:
+    name: "bats"
+    state: installed
+  ignore_errors: yes
+
 - name: "Get /usr/bin/bats stat"
   stat:
     path: "/usr/bin/bats"

--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -1,15 +1,12 @@
 ---
-- name: install required packages
-  yum:
+- name: "Load OS variables"
+  include_vars: "{{ ansible_os_family }}.yml"
+
+- name: "install required packages"
+  package:
     name: "{{ item }}"
     state: installed
-  with_items:
-    - wget
-    - curl
-    - ruby
-    - yum-utils
-    - git
-    - sos
+  with_items: "{{ bats_packages }}"
 
 - name: "Install bats from package"
   package:

--- a/roles/bats/vars/Debian.yml
+++ b/roles/bats/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+bats_packages:
+  - wget
+  - curl
+  - ruby
+  - git

--- a/roles/bats/vars/RedHat.yml
+++ b/roles/bats/vars/RedHat.yml
@@ -1,0 +1,8 @@
+---
+bats_packages:
+  - wget
+  - curl
+  - ruby
+  - git
+  - yum-utils
+  - sos

--- a/roles/haveged/tasks/main.yml
+++ b/roles/haveged/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: 'Install Haveged (faster population of PRNG)'
-  yum:
+  package:
     name: haveged
     state: installed
 


### PR DESCRIPTION
With the goal of running a pipeline on Debian this allows using bats from a package (but falling back to git) and allows splitting the packages based on the OS. It also fixes the haveged role.