### PR TITLE
Use deep_merge on box hashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ group :test do
   gem 'rubocop'
 end
 
+gem 'deep_merge'
 gem 'librarian-puppet'
 gem 'puppet', '< 4.0.0'

--- a/lib/forklift/box_factory.rb
+++ b/lib/forklift/box_factory.rb
@@ -2,8 +2,16 @@ require 'json'
 require 'erb'
 require 'yaml'
 
+if Gem.loaded_specs['vagrant']
+  require 'vagrant/util/deep_merge'
+else
+  require 'deep_merge'
+end
+
 module Forklift
   class BoxFactory
+
+    include Vagrant::Util::DeepMerge if Gem.loaded_specs['vagrant']
 
     attr_accessor :boxes, :shells
 
@@ -49,7 +57,7 @@ module Forklift
         box['shell'] += " --installer-options='#{box['installer']}' " if box['shell'] && box['installer']
 
         if @boxes[name]
-          @boxes[name].merge!(box)
+          @boxes[name].deep_merge!(box)
         else
           @boxes[name] = box
         end
@@ -76,7 +84,7 @@ module Forklift
 
     def layer_base_box(box)
       return box unless (base_box = find_base_box(box['box']))
-      base_box.merge(box)
+      base_box.deep_merge(box)
     end
 
     def find_base_box(name)


### PR DESCRIPTION
This prevents wiping out of ansible configuration when needing to override a parameter. For example:

```
puppet-test:
  box: centos7-katello-nightly
  ansible:
    variable:
      foreman_installer_module_prs: theforeman/puppet/560
```

Without this change, the above would do nothing as the playbook definition and other variables from the base centos7-katello-nightly get wiped out since these are nested key/values.