### PR TITLE
Install rgen for module PRs

### DIFF
--- a/roles/foreman_installer/tasks/module_pr.yml
+++ b/roles/foreman_installer/tasks/module_pr.yml
@@ -11,6 +11,7 @@
   with_items:
     - yard
     - puppet-strings
+    - rgen # https://tickets.puppetlabs.com/browse/PDOC-168
   when: puppetlabs_gem.stat.exists
   tags:
     - packages


### PR DESCRIPTION
With Puppet 5 puppet-strings needs rgen installed until https://tickets.puppetlabs.com/browse/PDOC-168 is resolved.