### PR TITLE
Add SSH agent forwarding, and SSH push only

### DIFF
--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -5,6 +5,8 @@ centos7-devel:
     playbook: 'playbooks/devel.yml'
     group: 'devel'
     variables:
+      ssh_forward_agent: true
+      foreman_devel_github_push_ssh: True
       katello_devel_github_username: <REPLACE ME>
 
 centos7-hammer-devel:

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,11 @@ A Katello development environment can be deployed on CentOS 6 or 7. Ensure that 
 
   1. Copy `boxes.yaml.example` to `boxes.yaml`. If you already have a `boxes.yaml`, you can copy the entries in `boxes.yaml.example` to your `boxes.yaml`.
   2. Now, replace `<my_github_username>` with your github username
-  3. Fill in any other options, examples:
+  3. Fill in any ansible options, examples:
+    * `foreman_devel_github_push_ssh`: Force git to push over SSH when HTTPS remote is configured
+    * `ssh_forward_agent`: Forward local SSH keys to the box via ssh-agent
+    * `katello_devel_github_username`: Your GitHub username to set up repository forks
+  4. Fill in any foreman-installer options, examples:
     * `--katello-devel-use-ssh-fork`: will add your fork by SSH instead of HTTPS
     * `--katello-devel-fork-remote-name`: will change the naming convention for your fork's remote
     * `--katello-devel-upstream-remote-name`: will change the naming convention for the upstream (non-fork) repositories remote
@@ -35,11 +39,11 @@ centos7-devel:
     group: 'devel'
     variables:
       katello_devel_github_username: <REPLACE ME>
-      foreman_installer_options_internal_use_only:
-        - "--katello-devel-github-username {{ katello_devel_github_username }}"
-        - "--katello-devel-upstream-remote-name origin"
-        - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
-        - "--katello-devel-extra-plugins theforeman/foreman_discovery"
+      foreman_installer_options: "
+        --katello-devel-upstream-remote-name origin
+        --katello-devel-extra-plugins theforeman/foreman_remote_execution
+        --katello-devel-extra-plugins theforeman/foreman_discovery
+        "
 ```
 
 Lastly, spin up the box:

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -65,6 +65,7 @@ module Forklift
       config.vm.define box.fetch('name'), primary: box.fetch('default', false) do |machine|
         machine.vm.box = box.fetch('box_name')
         config.ssh.insert_key = false if SUPPORT_SSH_INSERT_KEY
+        config.ssh.forward_agent = box.fetch('ssh_forward_agent', nil) || @settings.fetch('ssh_forward_agent', false)
         machine.vm.box_check_update = true if SUPPORT_BOX_CHECK_UPDATE
 
         machine.vm.box_url = box.fetch('box_url') if box.key?('box_url')

--- a/playbooks/devel.yml
+++ b/playbooks/devel.yml
@@ -17,4 +17,5 @@
     - puppet_repositories
     - foreman_repositories
     - katello_repositories
+    - foreman_devel
     - foreman_installer

--- a/roles/foreman_devel/defaults/main.yml
+++ b/roles/foreman_devel/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+foreman_devel_github_push_ssh: False

--- a/roles/foreman_devel/tasks/github_push_ssh.yml
+++ b/roles/foreman_devel/tasks/github_push_ssh.yml
@@ -1,0 +1,11 @@
+---
+- name: "install git"
+  package:
+    name: 'git'
+    state: 'present'
+
+- name: 'Always push to github over ssh'
+  git_config:
+    name: 'url."git@github.com:".pushInsteadOf'
+    value: 'https://github.com/'
+    scope: system

--- a/roles/foreman_devel/tasks/main.yml
+++ b/roles/foreman_devel/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include: github_push_ssh.yml
+  when: foreman_devel_github_push_ssh

--- a/settings.yaml.example
+++ b/settings.yaml.example
@@ -7,3 +7,5 @@ sync_type: 'rsync'
 
 cachier:
   mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+
+ssh_forward_agent: True


### PR DESCRIPTION
To use these features, add `ssh_forward_agent: True` to settings.yaml, and add the `foreman_installer_trust_github` option to boxes.yaml:

E.g.
```yaml
centos7-devel:
  box: centos7
  ansible:
    playbook: 'playbooks/devel.yml'
    group: 'devel'
    variables:
      katello_devel_github_username: '<GitHub username>'
      foreman_installer_trust_github: True
      ssh_forward_agent: True
      foreman_installer_options: "--katello-devel-use-ssh-fork true"
```