### PR TITLE
run subscription-manager unregister and clean before registering

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -126,6 +126,12 @@ EOF
     rpm -e `rpm -qf /etc/rhsm/ca/candlepin-local.pem`
   fi
 
+  run subscription-manager unregister
+  echo "rc=${status}"
+  echo "${output}"
+  run subscription-manager clean
+  echo "rc=${status}"
+  echo "${output}"
   run yum erase -y 'katello-ca-consumer-*'
   echo "rc=${status}"
   echo "${output}"

--- a/containers/test/ansible/tests/container-content.bats
+++ b/containers/test/ansible/tests/container-content.bats
@@ -126,6 +126,8 @@ EOF
     rpm -e `rpm -qf /etc/rhsm/ca/candlepin-local.pem`
   fi
 
+  run subscription-manager unregister
+  run subscription-manager clean
   run yum erase -y 'katello-ca-consumer-*'
   run rpm -Uvh http://localhost/pub/katello-ca-consumer-latest.noarch.rpm
   run subscription-manager register --force --org="${ORGANIZATION_LABEL}" --activationkey="${ACTIVATION_KEY}"


### PR DESCRIPTION
sub-man in EL7.4 changed the register --force behaviour, and will fail
if the machine was previously registered somewhere else and unregister
does not succeed.

run unregister and clean to be sure no previous registration is visible.

see https://bugzilla.redhat.com/show_bug.cgi?id=1484830 for details.