### PR TITLE
Add optional storage configuration for libvirt provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ networks -- custom networks to use in addition to the management network
 disk_size -- specify the size (in gigabytes) of the box's virtual disk. This
              only sets the virtual disk size, so you will still need to
              resize partitions and filesystems manually.
+add_disks -- (libvirt provider only) specify additional libvirt volumes
 ansible -- updates the Ansible provisioner configuration including the
            playbook to be ran or any variables to set
 libvirt_options -- sets Libvirt specific options
@@ -145,6 +146,17 @@ with-sshfs:
 ```
 
 If you want to mount in the opposite direction, just change `reverse` to `False` or remove it entirely.
+
+Example with an additional disk (libvirt volume) presented as /dev/vdb in the vm:
+
+static:
+  box: centos7
+  hostname: mystatic.box.com
+  add_disks:
+    - size: 100GiB
+      device: vdb
+      type: qcow2
+```
 
 ### Customize Deployment Settings
 

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -204,6 +204,16 @@ module Forklift
         p.memory = box.fetch('memory').to_i * @settings['scale_memory'].to_i if box.fetch('memory', false)
         p.machine_virtual_size = box.fetch('disk_size') if box.fetch('disk_size', false)
 
+        box.fetch('add_disks', []).each do |disk|
+          type = disk.fetch('type', 'raw')
+          device = disk.fetch('device')
+          size = disk.fetch('size')
+          if type.nil? || device.nil? || size.nil?
+            raise "Error in add_disks configuration: type, device or size are missing #{disk}"
+          end
+          p.storage :file, :size => size, :type => type, :device => device
+        end
+
         box.fetch('libvirt_options', []).each do |opt, val|
           p.instance_variable_set("@#{opt}", val)
         end


### PR DESCRIPTION
This commit allows to define additional volumes in the boxes
configuration (e.g. boxes.yml). If using libvirt as provider,
additional volumes will then be created.