### PR TITLE
Allow a box to be specified primary.

### DIFF
--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -1,5 +1,6 @@
 ---
 centos7-devel:
+  primary: true
   box: centos7
   ansible:
     playbook: 'playbooks/devel.yml'

--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -6,25 +6,21 @@ boxes:
   debian8:
     box_name:   'debian/jessie64'
     image_name: !ruby/regexp '/Debian.*Jessie/'
-    default:    true
     pty:        true
 
   debian9:
     box_name:   'debian/stretch64'
     image_name: !ruby/regexp '/Debian.*Stretch/'
-    default:    true
     pty:        true
 
   centos6:
     box_name:   'centos/6'
     image_name: !ruby/regexp '/CentOS 6.*PV/'
-    default:    true
     pty:        true
 
   centos7:
     box_name:   'centos/7'
     image_name: !ruby/regexp '/CentOS 7.*PV/'
-    default:    true
     pty:        true
 
   centos7-atomic:

--- a/docs/library.md
+++ b/docs/library.md
@@ -34,7 +34,6 @@ Deploy a file with the base set of boxes the plugin requires:
 centos7:
   box_name:   'centos/7'
   image_name: !ruby/regexp '/CentOS 7.*PV/'
-  default:    true
   pty:        true
 ```
 

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -62,7 +62,7 @@ module Forklift
     end
 
     def define_vm(config, box = {})
-      config.vm.define box.fetch('name'), primary: box.fetch('default', false) do |machine|
+      config.vm.define box.fetch('name'), primary: box.fetch('primary', false) do |machine|
         machine.vm.box = box.fetch('box_name')
         config.ssh.insert_key = false if SUPPORT_SSH_INSERT_KEY
         config.ssh.forward_agent = box.fetch('ssh_forward_agent', nil) || @settings.fetch('ssh_forward_agent', false)

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -62,7 +62,9 @@ module Forklift
     end
 
     def define_vm(config, box = {})
-      config.vm.define box.fetch('name'), primary: box.fetch('primary', false) do |machine|
+      primary = box.fetch('primary', false)
+      autostart = box.fetch('autostart', false)
+      config.vm.define box.fetch('name'), primary: primary, autostart: autostart do |machine|
         machine.vm.box = box.fetch('box_name')
         config.ssh.insert_key = false if SUPPORT_SSH_INSERT_KEY
         config.ssh.forward_agent = box.fetch('ssh_forward_agent', nil) || @settings.fetch('ssh_forward_agent', false)


### PR DESCRIPTION
The present version takes the 'default' parameter of the boxes, which seems to be set on almost all boxes. This clearly contradicts the statement, that only a single box may be specified as primary.