### PR TITLE
Allow overriding the module pr strategy

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -9,6 +9,8 @@ foreman_installer_command: foreman-installer
 
 # Comma-separated list of "organization/module/pr_number", e.g. "katello/foreman_proxy_content/37,katello/certs/34"
 foreman_installer_module_prs: ""
+# Another option is checkout which can be useful if you're not based on master
+foreman_installer_module_prs_strategy: "merge"
 
 # There are two options, so a user can supply their own, and a playbook can
 # specify theirs. For example, katello needs "--disable-system-checks" so we

--- a/roles/foreman_installer/tasks/module_pr.yml
+++ b/roles/foreman_installer/tasks/module_pr.yml
@@ -28,7 +28,7 @@
       git clone https://github.com/{{ item.split("/")[0] }}/puppet-{{ item.split("/")[1] }} {{ item.split("/")[1] }} &&
       cd {{ item.split("/")[1] }} &&
       git fetch origin pull/{{ item.split("/")[2] }}/head:pr &&
-      git merge pr
+      git {{ foreman_installer_module_prs_strategy }} pr
   with_items: "{{ foreman_installer_module_prs.split(',') }}"
   tags:
     - packages


### PR DESCRIPTION
If you're testing a backport then it's not based on master. This almost guarantees conflicts. Master might even be incompatible with the target version. By using the checkout strategy you trust it's exactly as you want it to be. This is a fair assumption on backports.