### PR TITLE
Use curl instead of wget in bats

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -36,7 +36,7 @@ setup() {
 }
 
 @test "upload package" {
-  wget https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_errata_install/animaniacs-0.1-1.noarch.rpm -P /tmp
+  (cd /tmp; curl -O https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_errata_install/animaniacs-0.1-1.noarch.rpm)
   hammer repository upload-content --organization="${ORGANIZATION}"\
     --product="${PRODUCT}" --name="${YUM_REPOSITORY}" --path="/tmp/animaniacs-0.1-1.noarch.rpm" | grep -q "Successfully uploaded"
 }

--- a/bats/fb-proxy.bats
+++ b/bats/fb-proxy.bats
@@ -29,6 +29,6 @@ setup() {
 @test "content is available from proxy" {
   URL1="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
   URL2="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
-  wget $URL1 -P /tmp || wget $URL2 -P /tmp
+  (cd /tmp; curl -O $URL1 || curl -O $URL2)
   tFileExists /tmp/walrus-0.71-1.noarch.rpm && tNonZeroFile /tmp/walrus-0.71-1.noarch.rpm
 }

--- a/roles/bats/vars/Debian.yml
+++ b/roles/bats/vars/Debian.yml
@@ -1,6 +1,5 @@
 ---
 bats_packages:
-  - wget
   - curl
   - ruby
   - git

--- a/roles/bats/vars/RedHat.yml
+++ b/roles/bats/vars/RedHat.yml
@@ -1,6 +1,5 @@
 ---
 bats_packages:
-  - wget
   - curl
   - ruby
   - git


### PR DESCRIPTION
Mostly because base [centos7] systems don't have wget installed.

Found this when trying to run bats on centos7-hammer-devel box foretello PRs to test for breakage.