### PR TITLE
Use Koji repositories for Foreman nightly

### DIFF
--- a/playbooks/bats_pipeline_foreman_nightly.yml
+++ b/playbooks/bats_pipeline_foreman_nightly.yml
@@ -1,6 +1,8 @@
 - hosts: all
   become: true
   vars:
+    foreman_repositories_version: nightly
+    foreman_repositories_use_koji: true
     bats_tests:
       - "fb-test-foreman.bats"
       - "fb-finish.bats"


### PR DESCRIPTION
This is why nightlies keep failing and will perpetually fail. @ekohl 