### PR TITLE
Remove use of -q in bats UI checks

### DIFF
--- a/bats/fb-test-foreman.bats
+++ b/bats/fb-test-foreman.bats
@@ -4,7 +4,7 @@
 set -o pipefail
 
 @test "check web app is up" {
-  curl -sk "https://localhost$URL_PREFIX/users/login" | grep -q login-form
+  curl -sk "https://localhost$URL_PREFIX/users/login" | grep login-form
 }
 
 @test "wake up puppet agent" {
@@ -13,7 +13,7 @@ set -o pipefail
 }
 
 @test "check web app is still up" {
-  curl -sk "https://localhost$URL_PREFIX/users/login" | grep -q login-form
+  curl -sk "https://localhost$URL_PREFIX/users/login" | grep login-form
 }
 
 @test "check smart proxy is registered" {


### PR DESCRIPTION
Sometimes the UI health checks fail with a status 23 using curl
which can be avoided by dropping the quiet flag.