### PR TITLE
s/include/include_tasks/

### DIFF
--- a/containers/deploy.yml
+++ b/containers/deploy.yml
@@ -1,5 +1,5 @@
 ---
-- include: generate-certs.yml
+- include_tasks: generate-certs.yml
 
 - hosts: localhost
   gather_facts: no

--- a/containers/roles/certificates/tasks/main.yml
+++ b/containers/roles/certificates/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: ca.yml
+- include_tasks: ca.yml
 
-- include: certificate.yml
+- include_tasks: certificate.yml
   with_items: "{{ certificates_services }}"
 
-- include: client_rpm.yml
+- include_tasks: client_rpm.yml

--- a/containers/roles/foreman/tasks/main.yml
+++ b/containers/roles/foreman/tasks/main.yml
@@ -32,9 +32,9 @@
     - tfm-rubygem-foreman_hooks
     - tfm-rubygem-foreman_memcache
 
-- include: hacks.yml
+- include_tasks: hacks.yml
 
-- include: install-puma.yml
+- include_tasks: install-puma.yml
 
 - name: 'Remove bin/spring'
   file:
@@ -51,7 +51,7 @@
     src: "{{ role_path }}/files/katello.yaml"
     dest: "/etc/foreman/plugins/katello.yaml"
 
-- include: apipie-cache-index.yml
+- include_tasks: apipie-cache-index.yml
 
 - name: 'Deploy production database.yml'
   copy:

--- a/roles/dynflow_devel/tasks/main.yml
+++ b/roles/dynflow_devel/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: dynflow_install.yml
+- include_tasks: dynflow_install.yml

--- a/roles/foreman_devel/tasks/main.yml
+++ b/roles/foreman_devel/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: github_push_ssh.yml
+- include_tasks: github_push_ssh.yml
   when: foreman_devel_github_push_ssh

--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- include: packages.yml
+- include_tasks: packages.yml
 
-- include: locales.yml
+- include_tasks: locales.yml
   when: ansible_os_family == 'Debian'
 
-- include: module_pr.yml
+- include_tasks: module_pr.yml
   when: foreman_installer_module_prs != ""
 
-- include: install.yml
+- include_tasks: install.yml
   when: foreman_installer_upgrade == False
 
-- include: upgrade.yml
+- include_tasks: upgrade.yml
   when: foreman_installer_upgrade == True

--- a/roles/foreman_proxy_content/tasks/main.yaml
+++ b/roles/foreman_proxy_content/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- include: devel_install.yml
+- include_tasks: devel_install.yml
   when: (foreman_proxy_content_upgrade == False and devel is defined and devel == True)
 
-- include: install.yml
+- include_tasks: install.yml
   when: foreman_proxy_content_upgrade == False
 
-- include: upgrade.yml
+- include_tasks: upgrade.yml
   when: foreman_proxy_content_upgrade == True

--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: debian_release_repos.yml
+- include_tasks: debian_release_repos.yml
   when: ansible_os_family == 'Debian' and foreman_repositories_use_release
 
-- include: redhat_release_repos.yml
+- include_tasks: redhat_release_repos.yml
   when: ansible_os_family == 'RedHat' and foreman_repositories_use_release and not foreman_repositories_use_koji
 
-- include: koji_repos.yml
+- include_tasks: koji_repos.yml
   when: foreman_repositories_use_koji
 
 - name: 'Install foreman-release-scl'

--- a/roles/forklift/tasks/main.yml
+++ b/roles/forklift/tasks/main.yml
@@ -13,11 +13,11 @@
   when: forklift_state is undefined
 
 - name: 'Bring boxes up'
-  include: 'up.yml'
+  include_tasks: 'up.yml'
   when: forklift_state == 'up'
 
 - name: 'Destroy boxes'
-  include: 'destroy.yml'
+  include_tasks: 'destroy.yml'
   when: forklift_state == 'destroy'
 
 - name: 'Refresh inventory'

--- a/roles/freeipa_server/tasks/main.yml
+++ b/roles/freeipa_server/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: install_freeipa_server.yml
+- include_tasks: install_freeipa_server.yml
   become: true
-- include: install_freeipa_client.yml
+- include_tasks: install_freeipa_client.yml

--- a/roles/hammer_devel/tasks/main.yml
+++ b/roles/hammer_devel/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: hammer_install.yml
-- include: hammer_config.yml
+- include_tasks: hammer_install.yml
+- include_tasks: hammer_config.yml

--- a/roles/katello_repositories/tasks/main.yml
+++ b/roles/katello_repositories/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: release_repos.yml
+- include_tasks: release_repos.yml
   when: katello_repositories_use_release and not katello_repositories_use_koji
 
-- include: koji_repos.yml
+- include_tasks: koji_repos.yml
   when: katello_repositories_use_koji
 
-- include: qpid.yml
+- include_tasks: qpid.yml
   when: ansible_distribution_major_version == "6" and katello_repositories_version == 3.2

--- a/roles/powerdns/tasks/main.yml
+++ b/roles/powerdns/tasks/main.yml
@@ -37,8 +37,8 @@
     state: "restarted"
   when: pdns_configured.changed
 
-- include: "schema.mysql.yml"
+- include_tasks: "schema.mysql.yml"
   when: powerdns_db_backend == "gmysql"
 
-- include: "zones.yml"
+- include_tasks: "zones.yml"
   when: powerdns_zones

--- a/roles/puppet_repositories/tasks/main.yml
+++ b/roles/puppet_repositories/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: 'Include puppet {{ puppet_repositories_version }} for {{ ansible_os_family }}'
-  include: 'puppetlabs-{{ puppet_repositories_version }}-{{ ansible_os_family|lower }}.yml'
+  include_tasks: 'puppetlabs-{{ puppet_repositories_version }}-{{ ansible_os_family|lower }}.yml'


### PR DESCRIPTION
Include is being deprecated in ansible. We can either replace it with include_tasks (dynamic) or import_tasks (static). Here's the warning:

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use                                                                                                                                     
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.                                                                                                          
 This feature will be removed in a future release. Deprecation warnings can be                                                                                                                                     
disabled by setting deprecation_warnings=False in ansible.cfg.                                                                                                                                                     
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is                                                                                                                                    
 discouraged. The module documentation details page may explain more about this                                                                                                                                    
 rationale.. This feature will be removed in a future release. Deprecation                                                                                                                                         
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```