### PR TITLE
Refactor koji to handle multiple tasks

### DIFF
--- a/roles/koji/defaults/main.yml
+++ b/roles/koji/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 koji_host: 'http://koji.katello.org/kojihub'
-koji_task_id:
+koji_task_ids: []
 koji_repo_directory: "/tmp/koji-repo"
+koji_topurl: 'http://koji.katello.org/kojifiles'

--- a/roles/koji/tasks/main.yml
+++ b/roles/koji/tasks/main.yml
@@ -10,9 +10,10 @@
     state: 'directory'
 
 - name: 'Download RPMs'
-  command: "koji --server {{ koji_host }} download-task {{ koji_task_id }}"
+  command: "koji --server {{ koji_host }} download-task --topurl {{ koji_topurl }} {{ item }}"
   args:
     chdir: "{{ koji_repo_directory }}"
+  with_items: "{{ koji_task_ids }}"
 
 - name: 'Install createrepo'
   yum:
@@ -24,10 +25,10 @@
 
 - name: 'Add repo file'
   yum_repository:
-    name: "koji-task-{{ koji_task_id }}-repo"
+    name: "koji-forklift-task-repo"
     description: 'Local repository for Koji task RPMs'
     baseurl: "file://{{ koji_repo_directory }}"
-    file: "koji_task_repo_{{ koji_task_id }}"
+    file: "koji_forklift_task_repo"
     priority: 1
     enabled: yes
     gpgcheck: no


### PR DESCRIPTION
The top URL is also needed to download the results. Without it koji only
downloads 404 pages which createrepo doesn't like.