### PR TITLE
Skip checks on katello pipeline

### DIFF
--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -9,6 +9,7 @@
       - katello
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
+      - "--skip-checks-i-know-better"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
       - "--katello-enable-ostree=true"
     bats_tests:


### PR DESCRIPTION
Similar to 84ed9945287d7e2b1a14c8eeb323ace12eb923db we shouldn't check
DNS on rackspace VMs for the katello pipeline.