### PR TITLE
refs(572) - Support virtualenv for install ansible-container

### DIFF
--- a/containers/install-ansible-container.yml
+++ b/containers/install-ansible-container.yml
@@ -2,8 +2,21 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+    - set_fact:
+        inside_virtual_env: "{{ lookup('pipe', 'echo $VIRTUAL_ENV') }}"
+
+    - name: 'Create .tmp directory'
+      file:
+        path: .tmp
+        state: directory
+
+    - name: 'Clone ansible-container'
+      git:
+        repo: https://github.com/ansible/ansible-container.git
+        dest: .tmp/ansible-container
+        update: yes
+
     - name: 'Install ansible-container'
-      pip:
-        name: git+https://github.com/ansible/ansible-container.git
-        extra_args: -e .[docker,openshift] --upgrade --user
+      command: "pip install -e .[docker,openshift] --upgrade {{ '' if inside_virtual_env else '--user' }}"
+      args:
         chdir: .tmp/ansible-container


### PR DESCRIPTION
I had to revert to using command given the special nature in which ansible-container installs, seems the pip module doesn't always like the engine specification piece (i.e. [docker,openshift])