### PR TITLE
Use puppet 5 in 1.16

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -9,7 +9,7 @@ installers:
 
   - foreman: '1.16'
     katello: '3.5'
-    puppet: 4
+    puppet: 5
     boxes:
       - 'centos7'
       - 'debian8'


### PR DESCRIPTION
For Debian Stretch there are no puppet 4 packages and we support 5.