### PR TITLE
Support nonzero return code when checking for active swap

### DIFF
--- a/roles/swapfile/tasks/main.yml
+++ b/roles/swapfile/tasks/main.yml
@@ -29,6 +29,7 @@
 - name: get active swap
   shell: "swapon --summary | grep '^{{ swapfile_path }}'"
   register: swapfile_active
+  ignore_errors: True
 
 - name: "activate {{ swapfile_path }}"
   command: "swapon {{ swapfile_path }}"


### PR DESCRIPTION
Bringing up a new box with the swapfile role would not work due to the way the check is working. 

`
TASK [swapfile : get active swap] **********************************************
Wednesday 06 December 2017  14:31:58 -0500 (0:00:00.329)       0:00:10.813 **** 
fatal: [centos7-katello-bats-ci]: FAILED! => {"changed": true, "cmd": "swapon --summary | grep '^/swapfile'", "delta": "0:00:00.003715", "end": "2017-12-06 19:31:58.859845", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2017-12-06 19:31:58.856130", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
`

Easily verified by `vagrant up centos7-katello-bats-ci` (must be fresh for valid test)