### PR TITLE
Remove ensuring of .tmp_boxes

### DIFF
--- a/roles/forklift/tasks/up.yml
+++ b/roles/forklift/tasks/up.yml
@@ -1,9 +1,4 @@
 ---
-- name: 'Ensure .tmp_boxes directory'
-  file:
-    state: directory
-    path: "{{ current_directory }}/.tmp_boxes"
-
 - name: 'Write box file'
   copy:
     dest: "{{ current_directory }}/boxes.d/80-tmp-{{ forklift_name }}.yaml"


### PR DESCRIPTION
36d1fb9212d5b8041b2323dc6b7340e19be1e067 makes this redundant