### PR TITLE
Switch staging repositories to use pulp repos

### DIFF
--- a/roles/katello_repositories/defaults/main.yml
+++ b/roles/katello_repositories/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 katello_repositories_version: nightly
 katello_repositories_environment: release
+katello_repositories_pulp_version: 2.15
+katello_repositories_pulp_release: beta

--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -32,7 +32,7 @@
   yum_repository:
     name: pulp-koji
     description: "Pulp {{ katello_repositories_version }} Koji Repository"
-    baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/pulp/el{{ ansible_distribution_major_version }}/x86_64/"
+    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/{{ kaatello_repositories_pulp_release }}/{{ katello_repositories_pulp_version }}/{{ ansible_distribution_major_version }}Server/x86_64/"
     priority: 1
     gpgcheck: 0
 


### PR DESCRIPTION
No longer use the Koji repositories for staging. This should switch the pipeline over to these as well which is needed for it to pass.