### PR TITLE
run vagrant up with --no-parallel

### DIFF
--- a/roles/forklift/tasks/up.yml
+++ b/roles/forklift/tasks/up.yml
@@ -4,7 +4,9 @@
     dest: "{{ current_directory }}/boxes.d/80-tmp-{{ forklift_name }}.yaml"
     content: "{{ forklift_boxes | to_yaml }}"
 
+# using --no-parallel here to avoid problems with libvirt storage volumes
+# see https://github.com/vagrant-libvirt/vagrant-libvirt/issues/850
 - name: 'Bring up boxes'
-  command: "vagrant up {{ forklift_boxes.keys()|join(' ') }}"
+  command: "vagrant up --no-parallel {{ forklift_boxes.keys()|join(' ') }}"
   args:
     chdir: "{{ current_directory }}"


### PR DESCRIPTION
when running multiple forklift jobs in parallel, we often see errors
like:

    cmd: vagrant up pipeline-capsule-6.2-rhel7 pipeline-satellite-6.2-rhel7

    start: 2018-01-11 19:54:28.604487

    end: 2018-01-11 19:54:30.538259

    delta: 0:00:01.933772

    msg: non-zero return code

    stdout: Bringing machine 'pipeline-capsule-6.2-rhel7' up with 'libvirt' provider...
    Bringing machine 'pipeline-satellite-6.2-rhel7' up with 'libvirt' provider...

    stderr: ==> pipeline-satellite-6.2-rhel7: An error occurred. The error will be shown after all tasks complete.
    ==> pipeline-capsule-6.2-rhel7: An error occurred. The error will be shown after all tasks complete.
    An error occurred while executing multiple actions in parallel.
    Any errors that occurred are shown below.

    An unexpected error occurred when executing the action on the
    'pipeline-capsule-6.2-rhel7' machine. Please report this as a bug:

    Call to virStorageVolGetInfo failed: Storage volume not found: no storage vol with matching path '/var/lib/libvirt/images/sat-deploy_pipeline-capsule-6.2-rhel6.img'

this happens because the parallel (rhel6) job already defined the
storage, but did not create it yet.

using `--no-parallel` seems to workaround this, as now machines are
created sequentually. the performance impact is minimal, as we're only
changing the boot process, and the actual deployment still happens in
parallel using ansible.

See: https://github.com/vagrant-libvirt/vagrant-libvirt/issues/850