### PR TITLE
Add devel box that configures multiple plugins

### DIFF
--- a/playbooks/luna-devel.yml
+++ b/playbooks/luna-devel.yml
@@ -1,0 +1,17 @@
+---
+- import_playbook: devel.yml
+  vars:
+    katello_devel_github_username: ''
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--katello-devel-github-username '{{ katello_devel_github_username }}'"
+      - "--katello-devel-enable-ostree=true"
+      - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
+      - "--katello-devel-extra-plugins theforeman/foreman_discovery"
+      - "--katello-devel-extra-plugins theforeman/foreman_ansible"
+      - "--katello-devel-extra-plugins theforeman/foreman-tasks"
+      - "--katello-devel-extra-plugins theforeman/foreman_bootdisk"
+      - "--katello-devel-extra-plugins theforeman/foreman_openscap"
+      - "--katello-devel-extra-plugins theforeman/foreman_templates"
+      - "--katello-devel-extra-plugins theforeman/foreman_hooks"
+      - "--katello-devel-extra-plugins theforeman/foreman_docker"

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+  become: true
+  vars:
+    foreman_installer_options:
+      - "--disable-system-checks"
+      - "--foreman-admin-password {{ foreman_installer_admin_password }}"
+      - "--enable-foreman-plugin-ansible"
+      - "--enable-foreman-plugin-discovery"
+      - "--enable-foreman-plugin-bootdisk"
+      - "--enable-foreman-plugin-hooks"
+      - "--enable-foreman-plugin-openscap"
+      - "--enable-foreman-plugin-templates"
+      - "--enable-foreman-plugin-remote-execution"
+      - "--enable-foreman-proxy-plugin-remote-execution-ssh"
+      - "--enable-foreman-proxy-plugin-discovery"
+      - "--enable-foreman-proxy-plugin-ansible"
+      - "--enable-foreman-proxy-plugin-openscap"
+  roles:
+    - role: katello

--- a/roles/foreman_installer/tasks/install.yml
+++ b/roles/foreman_installer/tasks/install.yml
@@ -3,7 +3,8 @@
   shell: >
       {{ foreman_installer_command }} {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
       --scenario "{{ foreman_installer_scenario }}"
-      {{ foreman_installer_options }}
+      {{ foreman_installer_options | join(" ") if foreman_installer_options is iterable else '' }}
+      {{ foreman_installer_options if foreman_installer_options is string else '' }}
       {{ foreman_installer_options_internal_use_only | join(" ") }}
   when: not foreman_installer_skip_installer
   tags:

--- a/vagrant/boxes.d/01-builtin.yaml
+++ b/vagrant/boxes.d/01-builtin.yaml
@@ -27,3 +27,8 @@ boxes:
     box: centos7
     ansible:
       playbook: 'playbooks/runcible.yml'
+
+  centos7-luna:
+    box: centos7
+    ansible:
+      playbook: 'playbooks/luna.yml'

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -10,6 +10,15 @@ centos7-devel:
       foreman_devel_github_push_ssh: True
       katello_devel_github_username: <REPLACE ME>
 
+centos7-luna-devel:
+  box: centos7
+  memory: 9000
+  ansible:
+    playbook: 'playbooks/luna-devel.yml'
+    group: 'devel'
+    variables:
+      katello_devel_github_username: <REPLACE ME>
+
 centos7-hammer-devel:
   box: centos7
   memory: 512


### PR DESCRIPTION
This does not currently work due to (https://community.theforeman.org/t/rename-foreman-docker-git-repository-to-foreman-docker/8391). That will either have to get resolved, or we will have to add special code in puppet-katello_devel that handles the special case of foreman_docker.

You might ask yourself why is this named "charon". Well, it sounded better than "foreman_with_a_bunch_of_plugins" and was short and to the point. Charon is a moon or natural satellite of the dwarf Planet pluto. 