### PR TITLE
robottelo role, upgrade pip in virtualenv before installing requirements.txt

### DIFF
--- a/roles/robottelo/tasks/main.yml
+++ b/roles/robottelo/tasks/main.yml
@@ -26,6 +26,12 @@
     state: latest
     virtualenv: "{{ robottelo_virtualenv_path }}"
 
+- name: Upgrade pip in the virtualenv
+  pip:
+    name: pip
+    state: latest
+    virtualenv: "{{ robottelo_virtualenv_path }}"
+
 - name: Install requirements
   pip:
     requirements: "{{ robottelo_directory }}/requirements.txt"


### PR DESCRIPTION
robottelo test from playbook previously failed on rhel7 due to missing dependencies. It turned out the pip running from virtualenv (v 1.4.1) did not completely resolve dependencies of cryptography pkg:
```
~]# /root/robottelo/venv/bin/pip install cryptography -U
Requirement already up-to-date: cryptography in ./robottelo/venv/lib/python2.7/site-packages
Requirement already up-to-date: idna>=2.1 in ./robottelo/venv/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: asn1crypto>=0.21.0 in ./robottelo/venv/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: six>=1.4.1 in ./robottelo/venv/lib/python2.7/site-packages (from cryptography)
```
whereas outside venv (pip v 8.2.1):
```
~]# pip install cryptography -U
Requirement already up-to-date: cryptography in /usr/lib64/python2.7/site-packages
Requirement already up-to-date: cffi>=1.7; platform_python_implementation != "PyPy" in /usr/lib64/python2.7/site-packages (from cryptography)
Requirement already up-to-date: enum34; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: asn1crypto>=0.21.0 in /usr/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: idna>=2.1 in /usr/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: six>=1.4.1 in /usr/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: ipaddress; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography)
Requirement already up-to-date: pycparser in /usr/lib/python2.7/site-packages (from cffi>=1.7; platform_python_implementation != "PyPy"->cryptography)

```
This pr upgrades pip in virtualenv before installing from requirements.txt, consequently tests start to execute (though failing due to being run on plain Foreman):

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.5, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /root/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collected 7 items
2018-02-21 05:31:44 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/endtoend/test_api_endtoend.py F.s.FFF                      [100%]
```

