### PR TITLE
Set cpu_mode to host-passthrough for nested virtualization

### DIFF
--- a/boxes.d/01-builtin.yaml
+++ b/boxes.d/01-builtin.yaml
@@ -16,6 +16,7 @@ boxes:
   centos7-provision-nightly:
     box: centos7
     memory: 8096
+    cpu_mode: host-passthrough
     ansible:
       playbook:
         - 'playbooks/katello.yml'

--- a/lib/forklift/box_distributor.rb
+++ b/lib/forklift/box_distributor.rb
@@ -209,6 +209,7 @@ module Forklift
           override.vm.network network['type'], network['options']
         end
         p.cpus = box.fetch('cpus').to_i * @settings['scale_cpus'].to_i if box.fetch('cpus', false)
+        p.cpu_mode = box.fetch('cpu_mode') if box.fetch('cpu_mode', false)
         p.memory = box.fetch('memory').to_i * @settings['scale_memory'].to_i if box.fetch('memory', false)
         p.machine_virtual_size = box.fetch('disk_size') if box.fetch('disk_size', false)
 


### PR DESCRIPTION
Without this change, I was not able to use the nested provisioning, as I
was getting:

    could not find capabilities for arch=x86_64 domaintype=kvm

Also, running virt-host-validate was giving me:

    QEMU: Checking for hardware virtualization: FAIL
    (Only emulated CPUs are available, performance
    will be significantly limited)

As a workaround, I needed to run

    virsh edit forklift_centos7-provision-nightly

and set `<cpu mode="host-passthrough"` in there and reboot the host.