### PR TITLE
Issue 632: Fix foreman proxy playbook: the argument is no longer valid

### DIFF
--- a/playbooks/foreman_proxy_content.yml
+++ b/playbooks/foreman_proxy_content.yml
@@ -26,7 +26,6 @@
             --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
             --foreman-proxy-content-certs-tar "{{ foreman_proxy_content_certs_tar }}"
             --foreman-proxy-content-parent-fqdn "{{ server_fqdn.stdout }}"
-            --foreman-proxy-content-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"
             --puppet-server-foreman-url "{{ server_fqdn.stdout }}"'
       foreman_installer_additional_packages:
           - foreman-installer-katello


### PR DESCRIPTION
Fixes #632 