### PR TITLE
Add https in --puppet-server-foreman-url

### DIFF
--- a/playbooks/foreman_proxy_content.yml
+++ b/playbooks/foreman_proxy_content.yml
@@ -26,6 +26,6 @@
             --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
             --foreman-proxy-content-certs-tar "{{ foreman_proxy_content_certs_tar }}"
             --foreman-proxy-content-parent-fqdn "{{ server_fqdn.stdout }}"
-            --puppet-server-foreman-url "{{ server_fqdn.stdout }}"'
+            --puppet-server-foreman-url https://"{{ server_fqdn.stdout }}"'
       foreman_installer_additional_packages:
           - foreman-installer-katello


### PR DESCRIPTION
This is consistent with other occurences of --puppet-server-foreman-url