### PR TITLE
Do not disable IPv6 in the foreman pipeline

### DIFF
--- a/playbooks/bats_pipeline_foreman_nightly.yml
+++ b/playbooks/bats_pipeline_foreman_nightly.yml
@@ -18,7 +18,6 @@
     - umask
     - selinux
     - etc_hosts
-    - disable_ipv6
     - epel_repositories
     - puppet_repositories
     - foreman_repositories

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -29,7 +29,6 @@
     - umask
     - selinux
     - etc_hosts
-    - disable_ipv6
     - epel_repositories
     - puppet_repositories
     - foreman_repositories


### PR DESCRIPTION
This is a workaround for https://projects.theforeman.org/issues/12386 but is only needed on katello content proxies which run qdrouter. It also breaks because in our CI we use IPv6 to log into machines which means that halfway during the run we kill our own connection.