### PR TITLE
Deep merge box settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 
 group :test do
+  gem 'deep_merge'
   gem 'minitest'
   gem 'mocha'
   gem 'rake'

--- a/lib/forklift/box_factory.rb
+++ b/lib/forklift/box_factory.rb
@@ -2,6 +2,8 @@ require 'json'
 require 'erb'
 require 'yaml'
 
+require_relative 'compat'
+
 module Forklift
   class BoxFactory
 
@@ -37,7 +39,7 @@ module Forklift
         box = layer_base_box(box)
 
         if @boxes[name]
-          @boxes[name].merge!(box)
+          @boxes[name].deep_merge!(box)
         else
           @boxes[name] = box
         end
@@ -67,7 +69,7 @@ module Forklift
 
     def layer_base_box(box)
       return box unless (base_box = find_base_box(box['box']))
-      base_box.merge(box)
+      deep_merge(base_box, box)
     end
 
     def find_base_box(name)
@@ -79,7 +81,7 @@ module Forklift
       box = JSON.parse(JSON.dump(base_box))
 
       variables = {}
-      variables.merge!(box['ansible']['vars']) if box['ansible'] && box['ansible']['vars']
+      variables.merge!(box['ansible']['variables']) if box['ansible'] && box['ansible']['variables']
       variables.merge!(
         'foreman_repositories_version' => version['foreman'],
         'katello_repositories_version' => version['katello'],

--- a/lib/forklift/compat.rb
+++ b/lib/forklift/compat.rb
@@ -1,0 +1,13 @@
+if Gem.loaded_specs['vagrant']
+  require 'vagrant/util/deep_merge'
+else
+  require 'deep_merge'
+end
+
+def deep_merge(myself, other)
+  if Gem.loaded_specs['vagrant']
+    Vagrant::Util::DeepMerge.deep_merge(myself, other)
+  else
+    myself.deep_merge(other)
+  end
+end


### PR DESCRIPTION
This allows setting variables in base boxes and overriding a different set in variables on higher levels.

This was applied in 2d4e41bcf2a5a2cdbcec14050403d43ee0c3e8b3 but reverted in 2f357cc0ee8e63d25aa61c0df3d3cac5efba28d5 because we were using an ancient vagrant version in CI. Now that we've upgraded CI to the latest version, we can apply this again.