### PR TITLE
Use puppet-katello_devel directly and provide scenario

### DIFF
--- a/playbooks/devel.yml
+++ b/playbooks/devel.yml
@@ -1,15 +1,12 @@
 ---
-- hosts: devel
+- hosts: all
   become: true
   vars:
     katello_repositories_version: nightly
-    foreman_installer_scenario: katello-devel
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
-      - "--katello-devel-github-username {{ katello_devel_github_username }}"
-      - "--katello-devel-enable-ostree=true"
+    katello_repositories_environment: staging
+    foreman_installer_skip_installer: true
     foreman_installer_additional_packages:
-      - foreman-installer-katello-devel
+      - foreman-installer-katello
   roles:
     - etc_hosts
     - epel_repositories
@@ -17,5 +14,15 @@
     - puppet_repositories
     - foreman_repositories
     - katello_repositories
-    - foreman_devel
+    - foreman_installer
+
+- hosts: all
+  become: true
+  vars:
+    foreman_installer_scenario: katello-devel
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--katello-devel-enable-ostree=true"
+  roles:
+    - foreman_installer_devel_scenario
     - foreman_installer

--- a/roles/foreman_installer_devel_scenario/files/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel-answers.yaml
@@ -1,0 +1,34 @@
+---
+certs:
+  group: vagrant
+  deploy: true
+  generate: true
+katello_devel:
+  deployment_dir: /home/vagrant
+  user: vagrant
+  db_type: postgres
+  rvm: true
+foreman_proxy_content:
+  pulp_master: true
+  qpid_router_broker_addr: localhost
+foreman_proxy:
+  custom_repo: true
+  http: true
+  ssl_port: '9090'
+  templates: false
+  tftp: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+puppet:
+  server: true
+  server_environments_owner: apache
+  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+foreman_proxy::plugin::pulp:
+  enabled: true
+  pulpnode_enabled: false

--- a/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
@@ -1,0 +1,29 @@
+---
+:name: Katello devel
+:description:
+:log_dir: /var/log/foreman-installer
+:log_name: katello-devel.log
+:log_level: DEBUG
+:no_prefix: false
+:answer_file: /etc/foreman-installer/scenarios.d/katello-devel-answers.yaml
+:installer_dir: /usr/share/katello-installer-base
+:default_values_dir: /tmp
+:module_dirs:
+- /usr/share/foreman-installer/modules
+- /usr/share/katello-installer-base/modules
+:parser_cache_path:
+- /usr/share/foreman-installer/parser_cache/foreman.yaml
+- /usr/share/katello-installer-base/parser_cache/katello-devel.yaml
+:hiera_config: /usr/share/foreman-installer/config/foreman-hiera.conf
+:hook_dirs:
+- /usr/share/katello-installer-base/hooks
+:colors: true
+:order:
+- certs
+- katello_devel
+- foreman_proxy
+- foreman_proxy::plugin::pulp
+- foreman_proxy_content
+:password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE
+# Unused, but remains present for older config migrations
+:mapping: {}

--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: 'Install git'
+  package:
+    name: git
+    state: present
+
+- name: 'Copy scenario files'
+  copy:
+    src: "{{ role_path }}/files/{{ item }}"
+    dest: /etc/foreman-installer/scenarios.d
+  with_items:
+    - katello-devel.yaml
+    - katello-devel-answers.yaml
+
+- name: 'Remove current puppet-katello_devel'
+  file:
+    state: absent
+    path: /usr/share/katello-installer-base/modules/katello_devel
+
+- name: 'Clone latest puppet-katello_devel'
+  git:
+    repo: https://github.com/theforeman/puppet-katello_devel
+    dest: /usr/share/katello-installer-base/modules/katello_devel
+    update: yes
+
+- name: "Install gems to rebuild the kafo module cache"
+  gem:
+    name: puppet-strings
+    executable: /opt/puppetlabs/puppet/bin/gem


### PR DESCRIPTION
This adds a role that uses puppet-katello_devel directly from git
for development installs and moves the installer devel scenario
in Forklift. This is to provide a faster turn around and updates
when devel environments are broken.