### PR TITLE
add centos7 fips enabled vm

### DIFF
--- a/playbooks/fips.yml
+++ b/playbooks/fips.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  become : yes
+  gather_facts: no
+  roles:
+    - fips

--- a/roles/fips/tasks/main.yml
+++ b/roles/fips/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: 'Install dracut-fips'
+  package: 
+    name: dracut-fips
+    state: present
+
+- name: 'Run dracut to rebuild initramfs'
+  command: dracut --force
+
+- name: 'Get boot_uuid'
+  command: 'findmnt -no uuid /boot'
+  register: result
+
+- name: 'Edit kernel command-line to include the fips=1 and boot=UUID=XXXX or boot=LABEL=XXXX or boot=/dev/DEVICE argument'
+  shell: 'grubby --update-kernel=DEFAULT --args="fips=1 boot=UUID={{ result.stdout }}"'
+
+- name: reboot vm
+  shell: sleep 2 && shutdown -r +1 "Ansible reboot"
+  async: 0
+  poll: 0
+  ignore_errors: true
+
+- name: Waiting for reboot
+  local_action: wait_for 
+                host={{ ansible_ssh_host }}
+                state=started
+
+- name: 'Verify FIPS enabled - If failed means the machine is not FIPS enabled'
+  shell: cat /proc/sys/crypto/fips_enabled | grep 1

--- a/vagrant/boxes.d/01-builtin.yaml
+++ b/vagrant/boxes.d/01-builtin.yaml
@@ -23,6 +23,13 @@ boxes:
         - 'playbooks/katello_provisioning.yml'
       group: 'server'
 
+  centos7-fips:
+    box:   'centos7'
+    memory: 8096
+    ansible:
+      playbook: 'playbooks/fips.yml'
+      group: 'fips'
+
   runcible:
     box: centos7
     ansible:


### PR DESCRIPTION
The box will generate a VM with FIPS mode enabled. To spin the machine following command needs to be executed :  `vagrant up centos7-fips`

to verify if FIPS enabled in the newly generated machine execute : 

`cat /proc/sys/crypto/fips_enabled`

it should return 1 if FIPS enabled else 0