### PR TITLE
Handle openstack in vagrant inventory

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -33,7 +33,7 @@ def list_running_hosts():
         else:
             (_, host, key, value, provider) = line.split(',')
 
-        if key == 'state' and value == 'running':
+        if key == 'state' and value in ('active', 'running'):
             hosts[host] = get_host_details(host)
     return hosts
 


### PR DESCRIPTION
The openstack plugin reports the status active where the libvirt plugin
reports status running. By checking for both, we have a complete
inventory and the etc_hosts role can ensure the correct /etc/hosts
entries.