### PR TITLE
Use the PVHVM image for Debian Stretch

### DIFF
--- a/boxes.d/00-debian.yaml
+++ b/boxes.d/00-debian.yaml
@@ -8,7 +8,7 @@ boxes:
 
   debian9:
     box_name:   'debian/stretch64'
-    image_name: !ruby/regexp '/Debian.*Stretch/'
+    image_name: !ruby/regexp '/Debian.*Stretch.*PVHVM/'
     pty:        true
     scenarios:
       - foreman

--- a/boxes.d/00-ubuntu.yaml
+++ b/boxes.d/00-ubuntu.yaml
@@ -1,7 +1,7 @@
 boxes:
   ubuntu1604:
     box_name: 'generic/ubuntu1604'
-    image_name: !ruby/regexp '/Ubuntu.*16\.04.*PVHVM.*/'
+    image_name: !ruby/regexp '/Ubuntu.*16\.04.*PVHVM/'
     pty: true
     scenarios:
       - foreman


### PR DESCRIPTION
Looks like Rackspace introduced the OnMetal image for Stretch. This
forces a VM to be used.