### PR TITLE
Use modern ansible variable names

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -50,9 +50,9 @@ def get_host_details(host):
     config = paramiko.SSHConfig()
     config.parse(p.stdout)
     c = config.lookup(host)
-    return {'ansible_ssh_host': c['hostname'],
-            'ansible_ssh_port': c['port'],
-            'ansible_ssh_user': c['user'],
+    return {'ansible_host': c['hostname'],
+            'ansible_port': c['port'],
+            'ansible_user': c['user'],
             'ansible_ssh_private_key_file': c['identityfile'][0]}
 
 

--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -3,9 +3,9 @@
   lineinfile:
     dest: /etc/hosts
     regexp: ".*{{ item.replace('.', '-') }}$"
-    line: "{{ hostvars[item].ansible_ssh_host }} {{ item.replace('.', '-') }}.{{ etc_hosts_domain }} {{ item.replace('.', '-') }}"
+    line: "{{ hostvars[item].ansible_host }} {{ item.replace('.', '-') }}.{{ etc_hosts_domain }} {{ item.replace('.', '-') }}"
     state: present
-  when: hostvars[item].ansible_ssh_host is defined
+  when: hostvars[item].ansible_host is defined
   become: yes
   with_items: "{{ groups['all'] }}"
   tags:


### PR DESCRIPTION
Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port.

Since we're using Ansible 2.4+ we can use the modern version. This makes it compatible with Vagrant which outputs the modern versions when it detects a modern Ansible.