### PR TITLE
Change katello-devel compile order

### DIFF
--- a/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
@@ -20,9 +20,9 @@
 :colors: true
 :order:
 - certs
-- katello_devel
 - foreman_proxy
 - foreman_proxy::plugin::pulp
+- katello_devel
 - foreman_proxy_content
 :password: l7VtnWiPeKe412o2CVBM6yVbTkKGh6L_CKx4_zBkmUE
 # Unused, but remains present for older config migrations


### PR DESCRIPTION
https://github.com/theforeman/puppet-katello_devel/commit/e52881cfccffa16de434e80bd2af4a2ad23b9b1b made the registration optional by autodetecting the registration class.  This is dependent on the compile order. Since we compile katello_devel before foreman_proxy, this is not detected which means the service is not run at the right time.