### PR TITLE
Cert for webpack on chrome

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -59,9 +59,9 @@ cd foreman
 bundle exec foreman start
 ```
 
-### Webpack dev server & Firefox
+### Webpack dev server
 
-When using the dev server on Firefox you need to accept the self-signed certificate. You should go to `https://centos7-devel.example.com:3808` (or your equivalent) and add an exception for this certificate. Chrome does not throw any warnings if you have accepted the same certificate already for `https://centos7-devel.example.com`.
+When using the dev server on Firefox and Chrome you need to accept the self-signed certificate. You should go to `https://centos7-devel.example.com:3808` (or your equivalent) and add an exception for this certificate. 
 
 
 ## Koji Scratch Builds

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ bundle exec foreman start
 
 ### Webpack dev server
 
-When using the dev server on Firefox and Chrome you need to accept the self-signed certificate. You should go to `https://centos7-devel.example.com:3808` (or your equivalent) and add an exception for this certificate. 
+When using the dev server you need to accept the self-signed certificate. You should go to `https://centos7-devel.example.com:3808` (or your equivalent) and add an exception for this certificate. 
 
 
 ## Koji Scratch Builds


### PR DESCRIPTION
I was having an issue where it seems JS wasn't loading and UI elements could not be used. It seemed to be caused by ERR_CERT_AUTHORITY_INVALID issues. 

This was running chrome, so I didn't try this at first.

I followed these instruction and it seems to have fixed my issue. 