### PR TITLE
Add flag foreman_installer_skip to setup repositories only and quit

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 foreman_installer_additional_packages: []
 foreman_installer_admin_password: changeme
+foreman_installer_skip: False
 foreman_installer_skip_installer: False
 foreman_installer_verbose: True
 foreman_installer_scenario: foreman

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -14,3 +14,4 @@ dependencies:
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
     foreman_installer_additional_packages:
       - katello
+    when: foreman_installer_skip == False


### PR DESCRIPTION
Similar flag to foreman_installer_skip_installer but skipping both packages and installer
Useful when you want just setup repos and proceed manually what to install/upgrade.

E.g:
You got Nightly and run ansible to get Koji repos but don't want to apply package upgrade/install at all. 


Not sure about naming, I'm open to suggestions: 

1. foreman_installer_skip    <- chose this one
2. foreman_installer_skip_all
3. foreman_installer_no_packages

