### PR TITLE
Fix the centos7-hammer-devel box to `become` less

### DIFF
--- a/playbooks/hammer_devel.yml
+++ b/playbooks/hammer_devel.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: all
-  become: yes
   roles:
     - etc_hosts
     - git
-    - ruby_scl
+    - role: ruby_scl
+      become: yes
     - hammer_devel


### PR DESCRIPTION
Related to https://github.com/theforeman/forklift/pull/627 and https://github.com/theforeman/forklift/pull/668.

We want to install a hammer_devel environment in the `"{{ remote_user }}"`'s home directory, not root's.