### PR TITLE
Fix hostname for OpenStack instances

### DIFF
--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Build hosts file"
+- name: "Build hosts file (vagrant)"
   lineinfile:
     dest: /etc/hosts
     regexp: ".*{{ item.replace('.', '-') }}$"
@@ -10,3 +10,12 @@
   with_items: "{{ groups['all'] }}"
   tags:
     - env_setup
+
+- name: "Build hosts file (OpenStack)"
+  lineinfile:
+    dest: /etc/hosts
+    regexp: ".* {{ ansible_fqdn }}$"
+    line: "{{ facter_ec2_metadata['local-ipv4'] }} {{ ansible_fqdn }}"
+    state: present
+  when: facter_ec2_metadata is defined and facter_ec2_metadata['local-ipv4'] != facter_ec2_metadata['public-ipv4']
+  become: yes


### PR DESCRIPTION
This method of build hosts file is inadequate for OpenStack. 
https://github.com/theforeman/forklift/blob/master/roles/etc_hosts/tasks/main.yml#L2-L12


The original method create a fictive hostname for vagrnat instances. In OpenStack we need a little different view, we already have the real fqdn, but we are behind NAT. DNS server returns  our public IP (address of our router)  for our hostname.  This new task is run only if we are in a cloud (OpenStack).

