### PR TITLE
making module_pr work with puppet-foreman

### DIFF
--- a/roles/foreman_installer/tasks/module_pr.yml
+++ b/roles/foreman_installer/tasks/module_pr.yml
@@ -24,9 +24,9 @@
 - name: "install module PR into installer directory"
   shell: >
       cd {{ (item.split("/")[0] == 'theforeman') | ternary("/usr/share/foreman-installer/modules", "/usr/share/katello-installer-base/modules") }} &&
-      rm -rf {{ item.split("/")[1] }} &&
-      git clone https://github.com/{{ item.split("/")[0] }}/puppet-{{ item.split("/")[1] }} {{ item.split("/")[1] }} &&
-      cd {{ item.split("/")[1] }} &&
+      rm -rf {{ item.split("/")[1] | replace("puppet-", "") }} &&
+      git clone https://github.com/{{ item.split("/")[0] }}/puppet-{{ item.split("/")[1] | replace("puppet-", "") }} {{ item.split("/")[1] | replace("puppet-", "") }} &&
+      cd {{ item.split("/")[1] | replace("puppet-", "") }} &&
       git fetch origin pull/{{ item.split("/")[2] }}/head:pr &&
       git {{ foreman_installer_module_prs_strategy }} pr
   with_items: "{{ foreman_installer_module_prs.split(',') }}"


### PR DESCRIPTION
Trying to use foreman_installer_module_prs to test PRs from puppet-foreman repo fails with 
```
remote: Repository not found.
fatal: repository 'https://github.com/theforeman/puppet-puppet-foreman/' not found
```
This pr removes the `puppet-` prefix if it is supplied in the project name in foreman_installer_module_prs, if there is a more elegant way how to do this in an ansible loop, I'd welcome a suggestion :)