### PR TITLE
Check if taxonomies enabled before associating

### DIFF
--- a/roles/foreman_provisioning/tasks/configure_centos_7.yml
+++ b/roles/foreman_provisioning/tasks/configure_centos_7.yml
@@ -1,8 +1,3 @@
-- name: 'associate CentOS 7 media'
-  shell: >
-    {{ foreman_provisioning_hammer }} medium update --name "CentOS mirror" --organization-titles "{{ foreman_provisioning_organization }}" --location-titles "{{ foreman_provisioning_location }}"
-  when: foreman_repositories_version == 'nightly'
-
 - name: 'create CentOS 7'
   shell: >
     {{ foreman_provisioning_hammer }} os info --title "CentOS 7" ||

--- a/roles/foreman_provisioning/tasks/configure_fedora_27.yml
+++ b/roles/foreman_provisioning/tasks/configure_fedora_27.yml
@@ -1,8 +1,3 @@
-- name: 'associate Fedora 27 media'
-  shell: >
-    {{ foreman_provisioning_hammer }} medium update --name "Fedora mirror" --organization-titles "{{ foreman_provisioning_organization }}" --location-titles "{{ foreman_provisioning_location }}"
-  when: foreman_repositories_version == 'nightly'
-
 - name: 'create Fedora 27'
   shell: >
     {{ foreman_provisioning_hammer }} os info --title "Fedora 27" ||

--- a/roles/foreman_provisioning/tasks/main.yml
+++ b/roles/foreman_provisioning/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: 'disable default context for admin'
   shell: >
     {{ foreman_provisioning_hammer }} user update --login admin --default-organization-id 0 --default-location-id 0
-  when: foreman_provisioning_foreman_version == 'nightly' or foreman_provisioning_foreman_version is version_compare('1.17', '>=')
+  when: foreman_provisioning_use_taxonomies and (foreman_provisioning_foreman_version == 'nightly' or foreman_provisioning_foreman_version is version_compare('1.17', '>='))
 
 # Get the smart proxy ID of the local katello:
 - name: 'get smart proxy id'
@@ -165,7 +165,7 @@
     - Ubuntu mirror
   shell: >
     {{ foreman_provisioning_hammer }} medium update --name "{{ item }}" --organization-titles "{{ foreman_provisioning_organization }}" --location-titles "{{ foreman_provisioning_location }}"
-  when: foreman_provisioning_foreman_version == 'nightly'
+  when: foreman_provisioning_use_taxonomies and foreman_provisioning_foreman_version == 'nightly'
 
 
 - name: 'Setup CentOS 7 provisioning'


### PR DESCRIPTION
foreman_provisioning tries to associate things with taxonomies but does not check whether they are enabled. This causes problems when installing just foreman without katello.