### PR TITLE
test pipeline for a loadbalanced proxy setup

### DIFF
--- a/pipelines/pipeline_katello_lbproxy.yml
+++ b/pipelines/pipeline_katello_lbproxy.yml
@@ -14,6 +14,9 @@
       haproxy01:
         box: centos7
         memory: 3072
+      client01:
+        box: centos7
+        memory: 3072
   roles:
     - forklift
 
@@ -186,3 +189,50 @@
   roles:
     - selinux
     - haproxy
+
+- hosts:
+  - client01
+  become: yes
+  vars:
+    lbname: capsule.example.test
+  roles:
+    - etc_hosts
+    - puppet_repositories
+    - katello_repositories
+    - disable_firewall
+  tasks:
+    - name: discover facts from the other machines
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: yes
+      with_items:
+        - haproxy01
+        - katello01
+        - proxy01
+        - proxy02
+    - name: add {{ lbname }} hosts entry
+      lineinfile:
+        dest: /etc/hosts
+        line: "{{ hostvars['haproxy01'].ansible_default_ipv4.address }} {{ lbname }}"
+    - name: add puppet autosign entry
+      lineinfile:
+        path: /etc/puppetlabs/puppet/autosign.conf
+        line: "{{ ansible_fqdn }}"
+      delegate_to: proxy01
+    - name: fetch bootstrap.py
+      get_url:
+        url: https://raw.githubusercontent.com/Katello/katello-client-bootstrap/master/bootstrap.py
+        dest: /root/bootstrap.py
+        force: True
+    - name: execute bootstrap.py
+      command: python /root/bootstrap.py -l admin -p changeme -s {{ lbname }} -o 'Default Organization' -L 'Default Location' -g My_Hostgroup -a My_Activation_Key --unmanaged --puppet-ca-port 8141
+    - name: install ssh keys
+      authorized_key:
+        user: root
+        state: present
+        key: https://{{ hostvars[item].ansible_fqdn }}:9090/ssh/pubkey
+        validate_certs: False
+      with_items:
+        - proxy01
+        - proxy02
+        - katello01

--- a/pipelines/pipeline_katello_lbproxy.yml
+++ b/pipelines/pipeline_katello_lbproxy.yml
@@ -4,7 +4,7 @@
     forklift_boxes:
       katello01:
         box: centos7
-        memory: 6144
+        memory: 8192
       proxy01:
         box: centos7
         memory: 3072
@@ -13,10 +13,10 @@
         memory: 3072
       haproxy01:
         box: centos7
-        memory: 3072
+        memory: 2048
       client01:
         box: centos7
-        memory: 3072
+        memory: 2048
   roles:
     - forklift
 

--- a/pipelines/pipeline_katello_lbproxy.yml
+++ b/pipelines/pipeline_katello_lbproxy.yml
@@ -1,0 +1,188 @@
+- hosts: localhost
+  vars:
+    forklift_name: pipeline-katello-lbproxy
+    forklift_boxes:
+      katello01:
+        box: centos7
+        memory: 6144
+      proxy01:
+        box: centos7
+        memory: 3072
+      proxy02:
+        box: centos7
+        memory: 3072
+      haproxy01:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
+
+- hosts:
+  - katello01
+  - proxy01
+  - proxy02
+  - haproxy01
+  become: yes
+  roles:
+    - umask
+    - selinux
+    - etc_hosts
+    - update_os_packages
+    - epel_repositories
+    - haveged
+    - disable_firewall
+
+- hosts:
+  - katello01
+  - proxy01
+  - proxy02
+  become: yes
+  vars:
+    puppet_repositories_version: 4
+    katello_repositories_version: 3.6
+    foreman_repositories_version: 1.17
+    foreman_repositories_environment: staging
+    katello_repositories_environment: staging
+    foreman_installer_skip_installer: true
+  roles:
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer
+
+- hosts: katello01
+  become: yes
+  vars:
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--foreman-admin-password {{ foreman_installer_admin_password }}"
+      - "--enable-foreman-plugin-remote-execution"
+      - "--enable-foreman-proxy-plugin-remote-execution-ssh"
+    foreman_installer_additional_packages:
+      - katello
+  roles:
+    - foreman_installer
+  tasks:
+    - name: create hostgroup
+      command: "hammer hostgroup create --name My_Hostgroup --organizations 'Default Organization'"
+      ignore_errors: True
+    - name: create ak
+      command: "hammer activation-key create --name My_Activation_Key --organization 'Default Organization' --lifecycle-environment 'Library' --content-view 'Default Organization View'"
+      ignore_errors: True
+    - name: create domain
+      command: "hammer domain create --name {{ ansible_domain }}"
+      ignore_errors: True
+    - name: add domain to org
+      command: "hammer domain update --name {{ ansible_domain }} --organizations 'Default Organization' --locations 'Default Location'"
+      ignore_errors: True
+
+- hosts:
+  - proxy01
+  - proxy02
+  become: yes
+  serial: 1
+  vars:
+    lbname: capsule.example.test
+    foreman_proxy_content_server: katello01
+    foreman_installer_scenario: foreman-proxy-content
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--foreman-proxy-trusted-hosts {{ server_fqdn.stdout }}"
+      - "--foreman-proxy-trusted-hosts {{ ansible_nodename }}"
+      - "--foreman-proxy-foreman-base-url https://{{ server_fqdn.stdout }}"
+      - "--foreman-proxy-register-in-foreman true"
+      - "--foreman-proxy-oauth-consumer-key {{ oauth_consumer_key.stdout }}"
+      - "--foreman-proxy-oauth-consumer-secret {{ oauth_consumer_secret.stdout }}"
+      - "--foreman-proxy-content-certs-tar {{ foreman_proxy_content_certs_tar }}"
+      - "--foreman-proxy-content-parent-fqdn {{ server_fqdn.stdout }}"
+      - "--puppet-server-foreman-url https://{{ server_fqdn.stdout }}"
+      - "--puppet-dns-alt-names {{ lbname }}"
+      - "--puppet-ca-server {{ hostvars['proxy01'].ansible_fqdn }}"
+      - "--foreman-proxy-puppetca {{ (inventory_hostname == 'proxy01') | ternary('true','false') }}"
+      - "--puppet-server-ca {{ (inventory_hostname == 'proxy01') | ternary('true','false') }}"
+      - "--enable-foreman-proxy-plugin-remote-execution-ssh"
+    foreman_installer_additional_packages:
+      - foreman-installer-katello
+    foreman_proxy_content_certs_args: "--foreman-proxy-cname {{ lbname }}"
+    foreman_installer_custom_hiera: |
+      pulp::lazy_redirect_host: {{ lbname }}
+    foreman_proxies:
+      - proxy01
+      - proxy02
+  pre_tasks:
+    - block:
+      - name: install puppetserver for the puppet user
+        yum:
+          name: puppetserver
+          state: present
+      - name: create cert folders
+        file:
+          path: "/etc/puppetlabs/puppet/ssl/{{ item }}/"
+          state: directory
+          mode: 0750
+          owner: puppet
+          group: puppet
+        with_items:
+          - ['certs', 'private_keys', 'public_keys']
+      - name: copy the CA cert
+        copy:
+          src: /tmp/proxycerts/certs/ca.pem
+          dest: /etc/puppetlabs/puppet/ssl/certs/ca.pem
+          owner: puppet
+          group: puppet
+      - name: copy the prepared puppet certs
+        copy:
+          src: "/tmp/proxycerts/{{ item }}/{{ ansible_fqdn }}.pem"
+          dest: "/etc/puppetlabs/puppet/ssl/{{ item }}/{{ ansible_fqdn }}.pem"
+          owner: puppet
+          group: puppet
+        with_items:
+          - ['certs', 'private_keys', 'public_keys']
+      - name: restore context of /etc/puppetlabs/puppet/ssl/
+        command: restorecon -Rv /etc/puppetlabs/puppet/ssl/
+      when:
+        - inventory_hostname != 'proxy01'
+  roles:
+    - foreman_proxy_content
+    - foreman_installer
+  tasks:
+    - block:
+      - name: create certs for the other proxies
+        command: "puppet cert generate {{ hostvars[item].ansible_fqdn }} --dns_alt_names={{ lbname }}"
+        environment:
+          PATH: "/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin"
+        args:
+          creates: /etc/puppetlabs/puppet/ssl/certs/{{ hostvars[item].ansible_fqdn }}.pem
+        with_items:
+          - proxy02
+      - name: fetch the certs
+        fetch:
+          src: "/etc/puppetlabs/puppet/ssl/{{ item[0] }}/{{ hostvars[item[1]].ansible_fqdn }}.pem"
+          dest: "/tmp/proxycerts/{{ item[0] }}/{{ hostvars[item[1]].ansible_fqdn }}.pem"
+          flat: True
+        with_nested:
+          - ['certs', 'private_keys', 'public_keys']
+          - ['proxy02']
+      - name: fetch the CA cert
+        fetch:
+          src: /etc/puppetlabs/puppet/ssl/certs/ca.pem
+          dest: /tmp/proxycerts/certs/ca.pem
+          flat: True
+      when:
+        - inventory_hostname == 'proxy01'
+    - name: assign organization and location
+      command: "hammer proxy update --name {{ ansible_fqdn }} --organizations 'Default Organization' --locations 'Default Location'"
+      delegate_to: katello01
+
+- hosts:
+  - haproxy01
+  become: yes
+  vars:
+    selinux_state: 'permissive'
+    foreman_proxies:
+      - proxy01
+      - proxy02
+  roles:
+    - selinux
+    - haproxy

--- a/roles/foreman_proxy_content/defaults/main.yml
+++ b/roles/foreman_proxy_content/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 custom_install: False
 foreman_proxy_content_upgrade: False
+foreman_proxy_content_certs_args: ""

--- a/roles/foreman_proxy_content/tasks/install.yml
+++ b/roles/foreman_proxy_content/tasks/install.yml
@@ -42,7 +42,7 @@
   delegate_to: "{{ foreman_proxy_content_server }}"
 
 - name: 'Generate Certs'
-  command: foreman-proxy-certs-generate --foreman-proxy-fqdn {{ ansible_nodename }} --certs-tar {{ foreman_proxy_content_certs_tar }}
+  command: foreman-proxy-certs-generate --foreman-proxy-fqdn {{ ansible_nodename }} --certs-tar {{ foreman_proxy_content_certs_tar }} {{ foreman_proxy_content_certs_args }}
   delegate_to: "{{ foreman_proxy_content_server }}"
   when: foreman_proxy_certs_generate_exists.rc == 0
 

--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart haproxy
+  service:
+    name: haproxy
+    state: restarted

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: discover foreman proxies
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ foreman_proxies }}"
+- name: install haproxy
+  package:
+    name: haproxy
+    state: present
+- name: configure haproxy
+  template:
+    dest: /etc/haproxy/haproxy.cfg
+    src: haproxy.cfg.j2
+    validate: haproxy -c -f %s
+  notify:
+    - restart haproxy
+- name: enable haproxy
+  service:
+    name: haproxy
+    state: started
+    enabled: yes

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,177 @@
+#---------------------------------------------------------------------
+# Example configuration for a possible web application.  See the
+# full configuration options online.
+#
+#   http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# Global settings
+#---------------------------------------------------------------------
+global
+    # to have these messages end up in /var/log/haproxy.log you will
+    # need to:
+    #
+    # 1) configure syslog to accept network log events.  This is done
+    #    by adding the '-r' option to the SYSLOGD_OPTIONS in
+    #    /etc/sysconfig/syslog
+    #
+    # 2) configure local2 events to go to the /var/log/haproxy.log
+    #   file. A line like the following can be added to
+    #   /etc/sysconfig/syslog
+    #
+    #    local2.*                       /var/log/haproxy.log
+    #
+    log         127.0.0.1 local2
+
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+	log                 	global
+	retries             	3
+	timeout http-request	10s
+	timeout queue       	1m
+	timeout connect     	10s
+	timeout client      	1m
+	timeout server      	1m
+	timeout http-keep-alive 10s
+	timeout check       	10s
+	maxconn             	3000
+
+#https
+frontend https
+   bind *:443
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-https
+
+backend f-proxy-https
+   option tcp-check
+   balance source
+{% for host in foreman_proxies %}
+   server f-proxy-https-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:443 check
+{% endfor %}
+
+#http
+frontend http
+   bind *:80
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-http
+
+backend f-proxy-http
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-http-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:80 check
+{% endfor %}
+
+#amqp
+frontend amqp
+   bind *:5647
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-amqp
+
+backend f-proxy-amqp
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-amqp-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:5647 check
+{% endfor %}
+
+
+#anaconda
+frontend anaconda
+   bind *:8000
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-anaconda
+
+backend f-proxy-anaconda
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-anaconda-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:8000 check
+{% endfor %}
+
+#puppet
+frontend puppet
+   bind *:8140
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-puppet
+
+backend f-proxy-puppet
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-puppet-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:8140 check
+{% endfor %}
+
+#puppet-ca
+frontend puppet-ca
+   bind *:8141
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-puppet-ca
+
+backend f-proxy-puppet-ca
+   option tcp-check
+   balance roundrobin
+   server f-proxy-puppet-ca-1 {{ hostvars[foreman_proxies[0]].ansible_default_ipv4.address }}:8140 check
+
+#rhsm
+frontend rhsm
+   bind *:8443
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-rhsm
+
+backend f-proxy-rhsm
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-rhsm-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:8443 check
+{% endfor %}
+
+#scap
+frontend scap
+   bind *:9090
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-scap
+
+backend f-proxy-scap
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-scap-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:9090 check
+{% endfor %}
+
+#docker
+frontend docker
+   bind *:5000
+   mode tcp
+   option              	tcplog
+   default_backend f-proxy-docker
+
+backend f-proxy-docker
+   option tcp-check
+   balance roundrobin
+{% for host in foreman_proxies %}
+   server f-proxy-docker-{{loop.index}} {{ hostvars[host].ansible_default_ipv4.address }}:5000 check
+{% endfor %}


### PR DESCRIPTION
this adds a new pipeline that can be used to test basic proxy loadbalancing for katello by using an haproxy setup. it's not a full-blown setup as proposed in https://community.theforeman.org/t/user-survey-supporting-ha-smart-proxies/8832, just something that can be done with todays code already.

# what does this playbook do?
Installs a Katello 3.6, two proxies and places an HAproxy infront of these two, balancing all the services between both proxies. Then a client is added to test that setup

# current caveats

1. PuppetCA is not really load-balanceable and only runs on the first proxy, being a SPOF. Clients need to talk to a specific port on the HAProxy to reach the CA.
1. Making the second proxy a CA-client to the first one is a bit cumbersome, I wish the installer would handle that for us
1. Pulp generates different repo metadata on different proxies, so clients need to stick to their backend or the'll need to re-fetch the metadata all the time
1. SELinux is permissive on the HAProxy box