### PR TITLE
Add a google provider with examples

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -2,6 +2,8 @@ boxes:
   centos6:
     box_name:   'centos/6'
     image_name: !ruby/regexp '/CentOS 6.*PV/'
+    google_options:
+      image_family: 'centos-6'
     pty:        true
     scenarios:
       - foreman
@@ -10,6 +12,8 @@ boxes:
   centos7:
     box_name:   'centos/7'
     image_name: !ruby/regexp '/CentOS 7.*PV/'
+    google_options:
+      image_family: 'centos-7'
     pty:        true
     scenarios:
       - foreman

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -85,6 +85,7 @@ module Forklift
         configure_virtualbox(machine, box, networks)
         configure_rackspace(machine, box)
         configure_openstack_provider(machine, box)
+        configure_google_provider(machine, box)
         configure_synced_folders(machine, box)
         configure_sshfs(config, box)
         configure_nfs(config, box)
@@ -282,6 +283,22 @@ module Forklift
         p.image                = box.fetch('image_name')
 
         box.fetch('openstack_options', []).each do |opt, val|
+          p.instance_variable_set("@#{opt}", val)
+        end
+      end
+    end
+
+    def configure_google_provider(machine, box)
+      machine.vm.provider :google do |p, override|
+        override.ssh.private_key_path = '~/.ssh/id_rsa'
+
+        p.google_project_id = @settings['google_project_id']
+        p.google_client_email = @settings['google_client_email']
+        p.google_json_key_location = @settings['google_json_key_location']
+
+        override.vm.box = 'google/gce'
+
+        box.fetch('google_options', []).each do |opt, val|
           p.instance_variable_set("@#{opt}", val)
         end
       end

--- a/vagrant/settings.yaml.example
+++ b/vagrant/settings.yaml.example
@@ -11,3 +11,8 @@ cachier:
 ssh_forward_agent: True
 
 domain: 'example.com'
+
+# https://github.com/mitchellh/vagrant-google
+google_project_id: "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+google_client_email: "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
+google_json_key_location: "/path/to/your/private-key.json"


### PR DESCRIPTION
I was recently given a large credit to use for a year, and this is what I've been using to make forklift work with GCE.

Note: Rather than specifying an image, Google uses the concept of image families to ensure users are using the most up to date image.