### PR TITLE
enable CentOS CR repository when using EPEL

### DIFF
--- a/roles/epel_repositories/tasks/main.yml
+++ b/roles/epel_repositories/tasks/main.yml
@@ -6,3 +6,14 @@
   tags:
     - packages
   when: ansible_os_family == 'RedHat'
+
+- name: 'Enable CentOS-CR Repository'
+  ini_file:
+    path: /etc/yum.repos.d/CentOS-CR.repo
+    section: cr
+    option: enabled
+    value: 1
+    no_extra_spaces: True
+  tags:
+    - packages
+  when: ansible_distribution == 'CentOS'


### PR DESCRIPTION
EPEL is sometimes compiled against packages that are not in a released
CentOS version yet (because it was built against staging/RHEL). The CR
repository should contain exactly those pre-release bits.

Fixes the issue we see today with rubygem-rkerberos that requires a
newer libkrb5 than in CentOS 7.4

Not using the `yum_repository` module, because it is not able to enable
repositories without defining all the details of the repository, which
seems backwards, as the repo file is already present.
