### PR TITLE
Force destroy to ignore y/n prompt

### DIFF
--- a/roles/forklift/tasks/destroy.yml
+++ b/roles/forklift/tasks/destroy.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Destroy boxes'
-  command: "vagrant destroy {{ forklift_boxes.keys()|join(' ') }}"
+  command: "vagrant destroy -f {{ forklift_boxes.keys()|join(' ') }}"
   args:
     chdir: "{{ current_directory }}"
 


### PR DESCRIPTION
I honestly don't know when this broke, but I think recent versions of Vagrant ask you interactively.