### PR TITLE
Use a pre-built box for FIPS

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -23,3 +23,10 @@ boxes:
     box_name: centos7-atomic
     pty: true
     libvirt: http://cloud.centos.org/centos/7/atomic/images/CentOS-Atomic-Host-7-Vagrant-Libvirt.box
+
+  centos7-fips:
+    box_name: 'daviddavis/centos7-fips'
+    pty: true
+    scenarios:
+      - foreman
+      - katello

--- a/vagrant/boxes.d/01-builtin.yaml
+++ b/vagrant/boxes.d/01-builtin.yaml
@@ -23,13 +23,6 @@ boxes:
         - 'playbooks/katello_provisioning.yml'
       group: 'server'
 
-  centos7-fips:
-    box:   'centos7'
-    memory: 8096
-    ansible:
-      playbook: 'playbooks/fips.yml'
-      group: 'fips'
-
   runcible:
     box: centos7
     ansible:

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -29,6 +29,7 @@ installers:
     puppet: 5
     boxes:
       - 'centos7'
+      - 'centos7-fips'
       - 'debian8'
       - 'debian9'
       - 'ubuntu1604'


### PR DESCRIPTION
* Made FIPS-enabled CentOS 7 a base box type, like normal Centos 6/7
* Added FIPS-enabled CentOS 7 to versions.yaml so that it can be
  provisioned with nightly builds of Foreman, Katello, etc.