### PR TITLE
Use downcase hostname for VM domain

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -95,7 +95,7 @@ module Forklift
     end
 
     def create_domain(box)
-      box['domain'] || @settings['domain'] || "#{`hostname -s`.strip}.example.com"
+      box['domain'] || @settings['domain'] || "#{`hostname -s`.strip.downcase}.example.com"
     end
 
     def configure_nfs(config, box)


### PR DESCRIPTION
To prevent katello-installer failures:
https://github.com/Katello/katello-installer/blob/master/checks/hostname.rb#L31