### PR TITLE
Run minishift locally only

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -37,7 +37,7 @@ The minishift setup requires some customization due to resource requirements. Ru
 
 A playbook is also provided that can be used:
 
-    ansible-playbook tools/minishift-start.yml
+    ansible-playbook -l localhost tools/minishift-start.yml
 
 Ensure you login to minishift to start:
 


### PR DESCRIPTION
If you follow the [docs](https://github.com/theforeman/forklift/tree/master/containers#start-minishift), this playbook would run against all your running forklift vms as well as localhost, which I don't think is intended.