### PR TITLE
Append pub key instead of overwrite with private

### DIFF
--- a/roles/robottelo/tasks/ssh.yml
+++ b/roles/robottelo/tasks/ssh.yml
@@ -4,8 +4,11 @@
   args:
     creates: "{{ robottelo_ssh_key }}"
 
+- name: 'Get public key'
+  command: cat {{ robottelo_ssh_key }}.pub
+  register: robottelo_public_key
+
 - name: 'Add ssh key to authorized_keys'
-  copy:
-    remote_src: true
-    src: "{{ robottelo_ssh_key }}"
-    dest: /root/.ssh/authorized_keys
+  authorized_key:
+    key: "{{ robottelo_public_key.stdout }}"
+    user: "{{ robottelo_ssh_username }}"


### PR DESCRIPTION
We don't ever want to overwrite `authorized_keys`, and we definitely don't want private keys in there.