### PR TITLE
become: true for robottelo

### DIFF
--- a/playbooks/robottelo.yml
+++ b/playbooks/robottelo.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: server foreman-proxy-content
   roles:
-    - robottelo
+    - role: robottelo
+      become: true


### PR DESCRIPTION
Currently the entire robottelo playbook runs from `/root/robottelo`, and ssh keys are generated/added to the root user.