### PR TITLE
WIP: Docker Compose configuration

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  foreman:
+    build: images/foreman
+    ports:
+      - 80
+    links:
+      - memcache
+      - postgres
+
+  memcache:
+    image: memcached
+
+  postgres:
+    image: postgres:9.6
+    environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - ./.data/db:/var/lib/postgresql/data/pgdata:z


### PR DESCRIPTION
This is a follow-up to the [discussion on the Foreman Community forum](https://community.theforeman.org/t/foreman-docker-compose-github-theforeman/6225/7). I'm interested in getting the simplest Docker Compose configuration running with the images provided by forklift.

When I run ...
```bash
$ docker-compose up 
```
... the `foreman` image is built and The Foreman starts up connecting successfully to the `postgres` container. Then, of course, the process starts to fail with `FATAL:  role "foreman" does not exist` first and the `foreman` container exiting with a stacktrace in the end.

I've consulted the architecture and setup-and-install documentation in the `docs` folder, and I'm wondering if I have to setup the entire infrastrucure. Can you help me understand?