### PR TITLE
Update foreman_repositories

### DIFF
--- a/roles/foreman_repositories/defaults/main.yml
+++ b/roles/foreman_repositories/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 foreman_repositories_version: nightly
 foreman_repositories_environment: release
+foreman_repositories_plugins: true

--- a/roles/foreman_repositories/tasks/debian_release_repos.yml
+++ b/roles/foreman_repositories/tasks/debian_release_repos.yml
@@ -8,7 +8,7 @@
     repo: deb http://deb.theforeman.org {{ ansible_distribution_release }} {{ foreman_repositories_version }}
     state: present
 
-- name: 'Install Foreman plugins repository'
+- name: 'Manage Foreman plugins repository'
   apt_repository:
     repo: deb http://deb.theforeman.org plugins {{ foreman_repositories_version }}
-    state: present
+    state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"

--- a/roles/foreman_repositories/tasks/debian_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/debian_staging_repos.yml
@@ -8,8 +8,8 @@
     repo: "deb http://stagingdeb.theforeman.org {{ ansible_distribution_release }} theforeman-{{ foreman_repositories_version }}"
     state: present
 
-- name: 'Install Foreman plugins repository'
+- name: 'Setup Foreman plugins repository'
   apt_repository:
     # No plugins staging repository
     repo: "deb http://deb.theforeman.org plugins {{ foreman_repositories_version }}"
-    state: present
+    state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"

--- a/roles/foreman_repositories/tasks/redhat_release_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_release_repos.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup Foreman Repository'
   yum:
-    name: http://yum.theforeman.org/{{ "releases/" if foreman_repositories_version != 'nightly' else '' }}{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
+    name: https://yum.theforeman.org/releases/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
     state: present
   tags:
     - packages

--- a/roles/foreman_repositories/tasks/redhat_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_staging_repos.yml
@@ -19,6 +19,7 @@
 - name: 'Foreman Plugins Koji repository'
   yum_repository:
     name: foreman-plugins-koji
+    state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"
     description: "Foreman Plugins {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-plugins-{{ foreman_repositories_version }}/RHEL/{{ ansible_distribution_major_version }}/x86_64/"
     priority: 1


### PR DESCRIPTION
* Allows removal of the plugins repository
* Retrieves the foreman-release RPM over https
* Simplify the foreman-release RPM URL