### PR TITLE
Fix katello 3.7 upgrade pipeline

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -203,6 +203,11 @@ EOF
   tPackageExists walrus-5.21
 }
 
+# it seems walrus lingers around making subsequent runs fail, so lets test package removal!
+@test "package remove (katello-agent)" {
+  timeout 300 hammer host package remove --host $(hostname -f) --packages walrus
+}
+
 @test "add puppet module to content view" {
   repo_id=$(hammer repository list --organization="${ORGANIZATION}" \
     | grep Puppet | cut -d\| -f1 | egrep -i '[0-9]+')

--- a/pipelines/pipeline_katello_36_to_37_upgrade.yml
+++ b/pipelines/pipeline_katello_36_to_37_upgrade.yml
@@ -31,6 +31,7 @@
     - update_os_packages
     - haveged
     - disable_firewall
+    - foreman_installer
 
 - hosts: pipeline-katello-3.6-3.7-centos7
   become: yes
@@ -75,6 +76,7 @@
   roles:
     - bats
 
+# Upgrade server to 3.7 & Puppet 5
 - hosts: pipeline-katello-3.6-3.7-centos7
   become: true
   vars:
@@ -86,9 +88,12 @@
     foreman_installer_scenario: katello
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
+    puppet_repositories_version: 5
   roles:
+    - puppet_repositories
     - foreman_repositories
     - katello_repositories
+    - update_os_packages
     - foreman_installer
 
 - hosts: pipeline-katello-3.6-3.7-centos7
@@ -103,46 +108,26 @@
   roles:
     - bats
 
-# Upgrade to Puppet 5
-# http://projects.theforeman.org/projects/foreman/wiki/Upgrading_from_Puppet_4_to_5#Prepare-And-Run-The-Installer
-- hosts:
-  - pipeline-katello-3.6-3.7-centos7
-  - pipeline-proxy-3.6-3.7-centos7
-  become: true
-  vars:
-    puppet_repositories_version: 5
-  roles:
-    - puppet_repositories
-
-- hosts:
-  - pipeline-katello-3.6-3.7-centos7
-  - pipeline-proxy-3.6-3.7-centos7
-  become: true
-  tasks:
-    - name: 'Update packages'
-      yum:
-        name: '*'
-        state: latest
-
-- hosts: pipeline-katello-3.6-3.7-centos7
-  become: true
-  vars:
-    foreman_installer_scenario: katello
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
-  roles:
-    - foreman_installer
-
+# Upgrade proxy
 - hosts: pipeline-proxy-3.6-3.7-centos7
   become: true
   vars:
     foreman_installer_scenario: foreman-proxy-content
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
+    foreman_proxy_content_upgrade: True
+    foreman_proxy_content_server: pipeline-katello-3.6-3.7-centos7
+    foreman_proxy_content_certs_args: "--certs-update-all"
+    puppet_repositories_version: 5
+    katello_repositories_version: 3.7
+    foreman_repositories_version: 1.18
+    foreman_repositories_environment: staging
+    katello_repositories_environment: staging
   roles:
-    - foreman_installer
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - update_os_packages
+    - foreman_proxy_content
 
-# Validate puppet upgrade
 - hosts: pipeline-katello-3.6-3.7-centos7
   become: true
   vars:

--- a/roles/foreman_proxy_content/tasks/certs_generate.yml
+++ b/roles/foreman_proxy_content/tasks/certs_generate.yml
@@ -1,0 +1,22 @@
+---
+- name: 'Detect certs generate'
+  command: "which foreman-proxy-certs-generate"
+  ignore_errors: true
+  register: foreman_proxy_certs_generate_exists
+  delegate_to: "{{ foreman_proxy_content_server }}"
+
+- name: 'Generate Certs'
+  command: foreman-proxy-certs-generate --foreman-proxy-fqdn {{ ansible_nodename }} --certs-tar {{ foreman_proxy_content_certs_tar }} {{ foreman_proxy_content_certs_args }}
+  delegate_to: "{{ foreman_proxy_content_server }}"
+  when: foreman_proxy_certs_generate_exists.rc == 0
+
+- name: 'Fetch Certs'
+  delegate_to: "{{ foreman_proxy_content_server }}"
+  fetch:
+    src: "{{ foreman_proxy_content_certs_tar }}"
+    dest: /tmp
+
+- name: 'Copy Certs to Capsule'
+  copy:
+    src: "/tmp/{{ inventory_hostname }}{{ foreman_proxy_content_certs_tar }}"
+    dest: ~/

--- a/roles/foreman_proxy_content/tasks/install.yml
+++ b/roles/foreman_proxy_content/tasks/install.yml
@@ -35,32 +35,7 @@
   delegate_to: "{{ foreman_proxy_content_server }}"
   register: pulp_oauth_secret
 
-- name: 'Detect certs generate'
-  command: "which foreman-proxy-certs-generate"
-  ignore_errors: true
-  register: foreman_proxy_certs_generate_exists
-  delegate_to: "{{ foreman_proxy_content_server }}"
-
-- name: 'Generate Certs'
-  command: foreman-proxy-certs-generate --foreman-proxy-fqdn {{ ansible_nodename }} --certs-tar {{ foreman_proxy_content_certs_tar }} {{ foreman_proxy_content_certs_args }}
-  delegate_to: "{{ foreman_proxy_content_server }}"
-  when: foreman_proxy_certs_generate_exists.rc == 0
-
-- name: 'Generate Certs'
-  command: capsule-certs-generate --capsule-fqdn {{ ansible_nodename }} --certs-tar {{ foreman_proxy_content_certs_tar }}
-  delegate_to: "{{ foreman_proxy_content_server }}"
-  when: foreman_proxy_certs_generate_exists.rc != 0
-
-- name: 'Fetch Certs'
-  delegate_to: "{{ foreman_proxy_content_server }}"
-  fetch:
-    src: "{{ foreman_proxy_content_certs_tar }}"
-    dest: /tmp
-
-- name: 'Copy Certs to Capsule'
-  copy:
-    src: "/tmp/{{ inventory_hostname }}{{ foreman_proxy_content_certs_tar }}"
-    dest: ~/
+- include_tasks: certs_generate.yml
 
 - name: 'Change cert permissions'
   file: path='/etc/pki/katello/private' mode=0775

--- a/roles/foreman_proxy_content/tasks/upgrade.yml
+++ b/roles/foreman_proxy_content/tasks/upgrade.yml
@@ -1,4 +1,6 @@
 ---
+- include_tasks: certs_generate.yml
+
 - name: 'Run installer upgrade'
   command: >
     foreman-installer
@@ -6,3 +8,7 @@
     --scenario foreman-proxy-content
     --disable-system-checks
     --upgrade
+    --certs-update-all
+    --certs-regenerate=true
+    --certs-deploy=true
+    --foreman-proxy-content-certs-tar="{{ foreman_proxy_content_certs_tar }}"


### PR DESCRIPTION
This fixes the 3.6 to 3.7 upgrade pipeline except for the final fb-proxy.bats test after upgrading the proxy to 3.7+puppet5. I think I'm following the correct steps to perform the upgrades based on documentation.

The reason the last fb-proxy fails is because the pulp db has pending migrations. Running pulp-mange-db by hand fixes it, and running fb-proxy.bats by hand is then successful. Maybe we're missing something in the installer?

To reproduce:
```
ansible-playbook pipelines/pipeline_katello_36_to_37_upgrade.yml -e "forklift_state=up"
```

and sit tight ...

@ehelms @chris1984 could this be related to the mongo upgrade or maybe I'm performing the upgrade incorrectly?