### PR TITLE
Fix the disabling of epel

### DIFF
--- a/roles/epel_repositories/defaults/main.yml
+++ b/roles/epel_repositories/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 epel_repositories_state: present
+epel_repositories_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+epel_repositories_name: "{{ epel_repositories_url if epel_repositories_state == 'present' else 'epel-release' }}"

--- a/roles/epel_repositories/tasks/main.yml
+++ b/roles/epel_repositories/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup Epel Repository'
   yum:
-    name: http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: "{{ epel_repositories_name }}"
     state: "{{ epel_repositories_state }}"
   tags:
     - packages


### PR DESCRIPTION
When we use url in 'name',
disabling the epel repo with yum module
does not work. We need to change the name
to get desired effects.