### PR TITLE
Handle missing GitHub forks, add gem flexibility

### DIFF
--- a/roles/hammer_devel/defaults/main.yml
+++ b/roles/hammer_devel/defaults/main.yml
@@ -14,3 +14,9 @@ hammer_devel_repositories:
   - theforeman/hammer-cli-foreman-tasks
   - katello/hammer-cli-csv
   - katello/hammer-cli-katello
+hammer_devel_local_gems: |-
+  gem 'hammer_cli'
+    gem 'hammer_cli_katello'
+    gem 'hammer_cli_foreman_admin'
+    gem 'hammer_cli_foreman_tasks'
+    gem 'hammer_cli_csv'

--- a/roles/hammer_devel/tasks/hammer_config.yml
+++ b/roles/hammer_devel/tasks/hammer_config.yml
@@ -7,9 +7,11 @@
 
 - name: 'Configure hammer'
   command: cp ~/hammer-cli/config/cli_config.template.yml ~/.hammer/cli_config.yml
+  creates: ~/.hammer/cli_config.yml
 
 - name: 'Configure hammer-cli-foreman'
   command: cp ~/hammer-cli-foreman/config/foreman.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/foreman.yml
 
 - name: 'Update hammer-cli-foreman host'
   lineinfile:
@@ -31,21 +33,31 @@
 
 - name: 'Enable hammer-cli-foreman-admin'
   command: cp ~/hammer-cli-foreman-admin/config/foreman_admin.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/foreman_admin.yml
+  when: ('theforeman/hammer-cli-foreman-admin' in hammer_devel_repositories)
 
 - name: 'Configure hammer-cli-foreman-admin logging core'
   command: cp ~/hammer-cli-foreman-admin/config/cli.modules.d/foreman_admin_logging_core.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/foreman_admin_logging_core.yml
+  when: ('theforeman/hammer-cli-foreman-admin' in hammer_devel_repositories)
 
 - name: 'Configure hammer-cli-foreman-admin logging for katello'
   command: cp ~/hammer-cli-foreman-admin/config/cli.modules.d/foreman_admin_logging_katello.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/foreman_admin_logging_katello.yml
+  when: ('theforeman/hammer-cli-foreman-admin' in hammer_devel_repositories)
 
 - name: 'Configure hammer-cli-katello'
   command: cp ~/hammer-cli-katello/config/katello.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/katello.yml
+  when: ('katello/hammer-cli-katello' in hammer_devel_repositories)
 
 - name: 'Configure hammer-cli-csv'
   command: cp ~/hammer-cli-csv/config/csv.yml ~/.hammer/cli.modules.d/
+  creates: ~/.hammer/cli.modules.d/csv.yml
+  when: ('katello/hammer-cli-csv' in hammer_devel_repositories)
 
 - name: 'Alias hammer'
-  lineinfile: dest=~/.bash_profile line="alias hammer='BUNDLE_GEMFILE=~/hammer-cli-katello/Gemfile bundle exec hammer'"
+  lineinfile: dest=~/.bash_profile line="alias hammer='BUNDLE_GEMFILE=~/hammer-cli-foreman/Gemfile bundle exec hammer'"
 
 - name: 'Alias rake'
   lineinfile: dest=~/.bash_profile line="alias rake='bundle exec rake'"

--- a/roles/hammer_devel/tasks/hammer_install.yml
+++ b/roles/hammer_devel/tasks/hammer_install.yml
@@ -7,33 +7,43 @@
     remote: upstream
   with_items: "{{ hammer_devel_repositories }}"
 
-- name: 'Check if the fork remotes exist'
+- name: 'Check if the local fork remotes exist'
   shell: "git remote | grep ^{{ hammer_devel_github_fork_remote_name }}$"
   args:
     chdir: ~/{{ item.split('/')[1] }}
   ignore_errors: yes
+  changed_when: False
   with_items: "{{ hammer_devel_repositories }}"
-  register: fork_remotes_exist
+  register: local_fork_remotes_exist
 
-- name: 'Add fork remotes to cloned repositories'
-  command: "git remote add {{ hammer_devel_github_fork_remote_name }} git@github.com:{{ hammer_devel_github_username }}/{{ item.item.split('/')[1] }}.git"
-  when: item.rc != 0
+- name: 'Check the GitHub fork repos exist for missing local fork remotes'
+  shell: "git ls-remote --exit-code -h https://:@github.com/{{ hammer_devel_github_username }}/{{ item.item.split('/')[1] }}"
   args:
     chdir: ~/{{ item.item.split('/')[1] }}
-  with_items: "{{ fork_remotes_exist.results }}"
+  ignore_errors: yes
+  changed_when: False
+  with_items: "{{ local_fork_remotes_exist.results }}"
+  when: item.rc != 0
+  register: github_forks_exist
+
+- name: 'Add local fork remotes to cloned repositories'
+  command: "git remote add {{ hammer_devel_github_fork_remote_name }} git@github.com:{{ hammer_devel_github_username }}/{{ item.item.item.split('/')[1] }}.git"
+  when:
+    - ('skipped' not in item)
+    - item.rc == 0
+  args:
+    chdir: ~/{{ item.item.item.split('/')[1] }}
+  ignore_errors: yes
+  with_items: "{{ github_forks_exist.results }}"
 
 - name: 'Add local gems to Gemfile.local'
   blockinfile:
-    dest: ~/hammer-cli-katello/Gemfile.local
+    dest: ~/hammer-cli-foreman/Gemfile.local
     create: yes
     block: |
       gem 'pry'
       path '../' do
-        gem 'hammer_cli'
-        gem 'hammer_cli_foreman'
-        gem 'hammer_cli_foreman_admin'
-        gem 'hammer_cli_foreman_tasks'
-        gem 'hammer_cli_csv'
+        {{ hammer_devel_local_gems }}
       end
 
 - name: 'Install gem native dependencies'
@@ -44,4 +54,4 @@
   gem: name=bundler state=present
 
 - name: 'Install gems'
-  bundler: chdir=~/hammer-cli-katello state=present executable=~/bin/bundle
+  bundler: chdir=~/hammer-cli-foreman state=present executable=~/bin/bundle

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -25,9 +25,18 @@ centos7-hammer-devel:
   ansible:
     playbook: 'playbooks/hammer_devel.yml'
     group: 'hammer-devel'
-    variables:
-      hammer_devel_github_username: '<REPLACE ME>'
-      hammer_devel_github_fork_remote_name: 'origin'
+    variables: # defaults in roles/hammer_devel/defaults/main.yml
+      hammer_devel_github_username: <REPLACE ME>
+      hammer_devel_github_fork_remote_name: origin
+      hammer_devel_server: centos7-devel.custom-domain
+      hammer_devel_repositories:
+        - theforeman/hammer-cli
+        - theforeman/hammer-cli-foreman
+        - katello/hammer-cli-katello
+      hammer_devel_local_gems: |-
+        gem 'hammer_cli'
+          gem 'hammer_cli_foreman'
+          gem 'hammer_cli_katello'
 
 katello-remote-execution:
   box: centos7-katello-nightly


### PR DESCRIPTION
- Specify your own repos to clone.
- Clone repos without forks.
- Specify local gems to enable
- Run hammer from hammer-cli-foreman instead of hammer-cli-katello

Thanks to @johnpmitsch for suggesting improvements.