### PR TITLE
Only install xenstore-utils on Ubuntu

### DIFF
--- a/roles/rackspace_hostname/tasks/main.yml
+++ b/roles/rackspace_hostname/tasks/main.yml
@@ -11,6 +11,8 @@
       package:
         name: xenstore-utils
         state: present
+      # On the Debian Stretch image xe-guest-utilities already provides xenstore-read
+      when: ansible_distribution == 'Ubuntu'
 
     - name: Read the hostname
       command: xenstore-read vm-data/hostname


### PR DESCRIPTION
To avoid:
```
TASK [rackspace_hostname : Install xenstore-utils] *****************************
Tuesday 21 August 2018  07:52:13 +0000 (0:00:02.353)       0:01:16.256 ******** 
Tuesday 21 August 2018  07:52:13 +0000 (0:00:02.353)       0:01:16.248 ******** 
[0;31mfatal: [systest-foreman-debian9-1344]: FAILED! => changed=false [0m
[0;31m  cache_update_time: 1534837875[0m
[0;31m  cache_updated: false[0m
[0;31m  msg: |-[0m
[0;31m    '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"     install 'xenstore-utils'' failed: E: Sub-process /usr/bin/dpkg returned an error code (1)[0m
[0;31m  rc: 100[0m
[0;31m  stderr: |-[0m
[0;31m    E: Sub-process /usr/bin/dpkg returned an error code (1)[0m
[0;31m  stderr_lines:[0m
[0;31m  - 'E: Sub-process /usr/bin/dpkg returned an error code (1)'[0m
[0;31m  stdout: |-[0m
[0;31m    Reading package lists...[0m
[0;31m    Building dependency tree...[0m
[0;31m    Reading state information...[0m
[0;31m    The following additional packages will be installed:[0m
[0;31m      libxenstore3.0[0m
[0;31m    The following NEW packages will be installed:[0m
[0;31m      libxenstore3.0 xenstore-utils[0m
[0;31m    0 upgraded, 2 newly installed, 0 to remove and 1 not upgraded.[0m
[0;31m    Need to get 65.4 kB of archives.[0m
[0;31m    After this operation, 273 kB of additional disk space will be used.[0m
[0;31m    Get:1 http://mirror.rackspace.com/debian-security stretch/updates/main amd64 libxenstore3.0 amd64 4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10 [34.8 kB][0m
[0;31m    Get:2 http://mirror.rackspace.com/debian-security stretch/updates/main amd64 xenstore-utils amd64 4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10 [30.6 kB][0m
[0;31m    Fetched 65.4 kB in 0s (213 kB/s)[0m
[0;31m    Selecting previously unselected package libxenstore3.0:amd64.[0m
[0;31m    (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 26470 files and directories currently installed.)[0m
[0;31m    Preparing to unpack .../libxenstore3.0_4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10_amd64.deb ...[0m
[0;31m    Unpacking libxenstore3.0:amd64 (4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10) ...[0m
[0;31m    Selecting previously unselected package xenstore-utils.[0m
[0;31m    Preparing to unpack .../xenstore-utils_4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10_amd64.deb ...[0m
[0;31m    Unpacking xenstore-utils (4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10) ...[0m
[0;31m    dpkg: error processing archive /var/cache/apt/archives/xenstore-utils_4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10_amd64.deb (--unpack):[0m
[0;31m     trying to overwrite '/usr/bin/xenstore-exists', which is also in package xe-guest-utilities 7.0.0-24[0m
[0;31m    Errors were encountered while processing:[0m
[0;31m     /var/cache/apt/archives/xenstore-utils_4.8.4+xsa273+shim4.10.1+xsa273-1+deb9u10_amd64.deb[0m
[0;31m  stdout_lines: <omitted>[0m
	to retry, use: --limit @/home/jenkins/.ansible/retry-files/bats_pipeline_foreman_nightly.retry
```