### PR TITLE
Use nss-myhostname

### DIFF
--- a/pipelines/pipeline_foreman_nightly.yml
+++ b/pipelines/pipeline_foreman_nightly.yml
@@ -13,8 +13,6 @@
   become: yes
   vars:
     foreman_installer_options_internal_use_only:
-      # Because we don't have a correct reverse DNS in our CI
-      - "--skip-checks-i-know-better"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"

--- a/playbooks/bats_pipeline_foreman_nightly.yml
+++ b/playbooks/bats_pipeline_foreman_nightly.yml
@@ -2,8 +2,6 @@
   become: true
   vars:
     foreman_installer_options_internal_use_only:
-      # Because we don't have a correct reverse DNS in our CI
-      - "--skip-checks-i-know-better"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -11,8 +11,6 @@
       - katello
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
-      # Because we don't have a correct reverse DNS in our CI
-      - "--skip-checks-i-know-better"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
       - "--katello-enable-ostree=true"
       - "--puppet-server-max-active-instances 1"

--- a/roles/foreman/meta/main.yml
+++ b/roles/foreman/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies:
   - role: umask
   - role: selinux
+  - role: myhostname
   - role: rackspace_hostname
   - role: etc_hosts
   - role: epel_repositories

--- a/roles/myhostname/tasks/main.yml
+++ b/roles/myhostname/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Ensure nss-myhostname is installed
+  package:
+    name: libnss-myhostname
+    state: present
+  # On EL7 it's always installed
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
By using nss-myhostname we can rely on $HOSTNAME resolving to the correct IP - both forward and reverse. On EL7 this is installed by default but on Debian we need to install an additional package.