### PR TITLE
Add a script to download boxes from Jenkins jobs

### DIFF
--- a/bin/box-downloader
+++ b/bin/box-downloader
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+
+import click
+import requests
+import yaml
+
+@click.command()
+@click.argument('url')
+def download(url):
+    """Simple program to download Jenkins artifacts"""
+    session = requests.Session()
+
+    response = session.get(url + 'api/json')
+    response.raise_for_status()
+    data = response.json()
+
+    artifacts = {artifact['fileName']: artifact['relativePath'] for artifact in data['artifacts']
+                 if artifact['fileName'].endswith('.yaml')}
+
+    for filename, path in artifacts.items():
+        response = session.get(url + 'artifact/' + path)
+        response.raise_for_status()
+        target = os.path.join('vagrant/boxes.d', filename)
+        with open(target, 'wb') as fp:
+            click.echo('Downloading {} to {}'.format(filename, target))
+            fp.write(response.content)
+
+            boxes = yaml.load(response.content)
+            click.echo('Found boxes: {}'.format(' '.join(boxes.keys())))
+
+
+if __name__ == '__main__':
+    download()


### PR DESCRIPTION
This should make it easy to download the systest box definitions and run them locally:

```
$ ./bin/box-downloader "https://ci.theforeman.org/job/release_test/237/label=el&&ipv6,os=debian9/"
Downloading 80-tmp-systest-foreman-debian9-237.yaml to vagrant/boxes.d/80-tmp-systest-foreman-debian9-237.yaml
Found boxes: systest-foreman-debian9-237
```

Now it's a simple vagrant up systest-foreman-debian9-237 to rerun the tests.