### PR TITLE
Explicitly yum clean after setting up Foreman repositories

### DIFF
--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -9,3 +9,9 @@
   tags:
     - packages
   when: ansible_os_family == 'RedHat'
+
+- name: 'Clean yum'
+  command: 'yum clean expire-cache'
+  tags:
+    - packages
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
@ekohl All upgrade pipelines after failing recently due to this. I am not sure what changed to cause this, but this explicit clean does fix it in all cases I have tested. Nightlies can be seen failing for the same reason. This seems to only affect the plugin repository which is odd as well.

Example failure: https://ci.centos.org/job/foreman-katello-upgrade-3.8-test/6/consoleFull