### PR TITLE
Remove most default vars from example hammer box

### DIFF
--- a/roles/hammer_devel/defaults/main.yml
+++ b/roles/hammer_devel/defaults/main.yml
@@ -7,6 +7,7 @@ hammer_devel_server_port: 443
 hammer_devel_host: "{{ hammer_devel_server_protocol }}://{{ hammer_devel_server }}:{{ hammer_devel_server_port }}"
 hammer_devel_username: admin
 hammer_devel_password: changeme
+hammer_devel_github_fork_remote_name: "{{ hammer_devel_github_username }}"
 hammer_devel_repositories:
   - theforeman/hammer-cli
   - theforeman/hammer-cli-foreman

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -27,16 +27,7 @@ centos7-hammer-devel:
     group: 'hammer-devel'
     variables: # defaults in roles/hammer_devel/defaults/main.yml
       hammer_devel_github_username: <REPLACE ME>
-      hammer_devel_github_fork_remote_name: origin
-      hammer_devel_server: centos7-devel.custom-domain
-      hammer_devel_repositories:
-        - theforeman/hammer-cli
-        - theforeman/hammer-cli-foreman
-        - katello/hammer-cli-katello
-      hammer_devel_local_gems: |-
-        gem 'hammer_cli'
-          gem 'hammer_cli_foreman'
-          gem 'hammer_cli_katello'
+      #hammer_devel_server: centos7-devel.custom-domain
 
 katello-remote-execution:
   box: centos7-katello-nightly


### PR DESCRIPTION
There's really no good reason for new users to know about and change these removed settings. It works great with the defaults, and those options are really targeted toward more specialized circumstances (i.e. if you're developing a brand new hammer plugin). 

Fixes https://github.com/theforeman/forklift/issues/819