### PR TITLE
Force the lang to en_US.UTF-8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+ENV['LANG'] = 'en_US.UTF-8'
 VAGRANTFILE_DIR = File.dirname(__FILE__)
 
 require "#{VAGRANTFILE_DIR}/vagrant/lib/forklift"


### PR DESCRIPTION
If you have a locale set that's not present inside the VM the installer (correctly) errors out. We can rely on en_US.UTF-8 being present.

Fixes #657 