### PR TITLE
Switch away from SCL as we need Vagrant 2+

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -17,23 +17,24 @@ newgrp libvirt
 
 ## Centos 7
 
-For this you need EPEL and SCLo
+For this you need EPEL and Vagrant RPM
 
 ```bash
 yum -y install epel-release centos-release-scl
-yum -y install libvirt-daemon-kvm ansible sclo-vagrant1-vagrant-libvirt
+yum -y install libvirt-daemon-kvm ansible https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.rpm
 systemctl enable libvirtd
 systemctl start libvirtd
 ```
 
-Now you need to run commands in the vagrant SCL. The easiest is to start a new shell:
+Now you need to ensure your user can access vagrant and libvirt:
 
 ```bash
-scl enable sclo-vagrant1 bash
+usermod --append --groups libvirt `whoami`
 ```
 
-You can also manually load the SCL into your existing bash:
+Install vagrant libvirt plugin:
 
 ```bash
-. /opt/rh/sclo-vagrant1/enable
+sudo yum -y install install libxslt-devel libxml2-devel libvirt-devel libguestfs-tools-c ruby-devel gcc
+vagrant plugin install vagrant-libvirt
 ```


### PR DESCRIPTION
The SCL has vagrant 1.8.1 which points to the old Vagrant image repository which is no longer available at the old location.

This causes 404 errors trying to Vagrant up:
```bash
$ vagrant up fedora28
Bringing machine 'fedora28' up with 'libvirt' provider...
==> fedora28: Box 'fedora/28-cloud-base' could not be found. Attempting to find and install...
    fedora28: Box Provider: libvirt
    fedora28: Box Version: >= 0
The box 'fedora/28-cloud-base' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/fedora/28-cloud-base"]
Error: The requested URL returned error: 404 Not Found
```

updating to 2.1 fixes this issue
