### PR TITLE
Use Ruby SCL instead of RVM in devel

### DIFF
--- a/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
@@ -5,6 +5,8 @@
 :log_name: katello-devel.log
 :log_level: DEBUG
 :no_prefix: false
+# Forklift always overwrites the answers so let's not pretend we save them
+:dont_save_answers: true
 :answer_file: /etc/foreman-installer/scenarios.d/katello-devel-answers.yaml
 :installer_dir: /usr/share/foreman-installer/katello
 :module_dirs: /usr/share/foreman-installer/modules

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -15,5 +15,4 @@ dependencies:
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
       - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
-      - "--katello-devel-enable-ostree=true"
       - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -5,6 +5,7 @@ dependencies:
     foreman_server_repositories_ostree: true
     foreman_server_repositories_katello: true
     foreman_server_repositories_foreman_client: true
+  - role: ruby_scl
   - role: foreman_installer_devel_scenario
   - role: foreman_installer
     katello_repositories_version: nightly
@@ -13,5 +14,6 @@ dependencies:
       - foreman-installer-katello
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
+      - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
       - "--katello-devel-enable-ostree=true"
       - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"

--- a/roles/ruby_scl/defaults/main.yml
+++ b/roles/ruby_scl/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ruby_scl_version: rh-ruby24
+ruby_scl_version: rh-ruby25

--- a/roles/ruby_scl/tasks/main.yml
+++ b/roles/ruby_scl/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: 'Install SCL repository'
   yum:
-    name: centos-release-scl
+    name: centos-release-scl-rh
     state: present
 
 - name: 'Install Ruby SCL'


### PR DESCRIPTION
Also updates the default ruby version to 2.5 to match RPM packaging.