### PR TITLE
Foreman provisioning options must not be array

### DIFF
--- a/roles/foreman_provisioning/meta/main.yml
+++ b/roles/foreman_provisioning/meta/main.yml
@@ -22,5 +22,5 @@ dependencies:
       - "--foreman-proxy-tftp true"
       - "--foreman-proxy-tftp-managed false"
       - "--enable-foreman-compute-libvirt"
-      - "{{ foreman_provisioning_installer_options }}"
+      - "{{ foreman_provisioning_installer_options | join(' ') }}"
   - role: foreman_provisioning_infrastructure


### PR DESCRIPTION
Otherwise it generates an installer command like this which Kafo is quite unhappy with: `--enable-foreman-compute-libvirt [u'--disable-system-checks'] --foreman-admin-password changeme`