### PR TITLE
Switch to pulp nightly

### DIFF
--- a/roles/katello_repositories/defaults/main.yml
+++ b/roles/katello_repositories/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 katello_repositories_version: nightly
 katello_repositories_environment: release
-katello_repositories_pulp_version: 2.17
+katello_repositories_pulp_version: nightly
 katello_repositories_pulp_release: beta

--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -20,13 +20,25 @@
     priority: 1
     gpgcheck: 0
 
-- name: Add Pulp repository
+- name: Add Pulp Stable repository
   yum_repository:
     name: pulp-repository
     description: Pulp release repository
-    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/{{ katello_repositories_pulp_release }}/{{ katello_repositories_pulp_version }}/7Server/x86_64/"
+    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/{{ katello_repositories_pulp_release }}/{{ katello_repositories_pulp_version }}/$releasever/$basearch"
     gpgcheck: no
     enabled: yes
+  when:
+    - katello_repositories_pulp_version != "nightly"
+
+- name: Add Pulp Nightly repository
+  yum_repository:
+    name: pulp-repository
+    description: Pulp nightly repository
+    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/2-master/stage/$releasever/$basearch"
+    gpgcheck: no
+    enabled: yes
+  when:
+    - katello_repositories_pulp_version == "nightly"
 
 - name: 'Katello Client Koji repository'
   yum_repository:

--- a/roles/pulp_repositories/defaults/main.yml
+++ b/roles/pulp_repositories/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-pulp_repositories_version: '2.17'
+pulp_repositories_version: 'nightly'
 pulp_repositories_release: 'beta'

--- a/roles/pulp_repositories/tasks/main.yml
+++ b/roles/pulp_repositories/tasks/main.yml
@@ -1,11 +1,23 @@
 ---
-- name: Add Pulp repository
+- name: Add Pulp stable repository
   yum_repository:
     name: pulp-repository
     description: Pulp release repository
-    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/{{ pulp_repositories_release }}/{{ pulp_repositories_version }}/7Server/x86_64/"
+    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/{{ pulp_repositories_release }}/{{ pulp_repositories_version }}/$releasever/$basearch"
     gpgcheck: no
     enabled: yes
+  when:
+    - pulp_repositories_version != "nightly"
+
+- name: Add Pulp nightly repository
+  yum_repository:
+    name: pulp-repository
+    description: Pulp nightly repository
+    baseurl: "https://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/2-master/stage/$releasever/$basearch"
+    gpgcheck: no
+    enabled: yes
+  when:
+    - pulp_repositories_version == "nightly"
 
 - name: 'Gofer repository'
   yum_repository:


### PR DESCRIPTION
For Katello 2.10 development, we are using pulp's nightly builds
until the beta is released.