### PR TITLE
speed up playbooks by installing packages in one go

### DIFF
--- a/playbooks/runcible.yml
+++ b/playbooks/runcible.yml
@@ -19,22 +19,21 @@
 
     - name: 'Install packages'
       yum:
-        name: "{{ item }}"
+        name:
+          - ruby-devel
+          - rubygem-bundler
+          - libxml2-devel
+          - ruby
+          - rake
+          - gcc
+          - wget
+          - git
+          - nss
+          - puppet
+          - glib2
+          - ostree
         state: "present"
       become: true
-      with_items:
-        - ruby-devel
-        - rubygem-bundler
-        - libxml2-devel
-        - ruby
-        - rake
-        - gcc
-        - wget
-        - git
-        - nss
-        - puppet
-        - glib2
-        - ostree
 
     - name: "Install RVM gpg key"
       shell: "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"

--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -15,14 +15,11 @@
     forklift_url: "https://github.com/theforeman/forklift"
     forklift_version: master
   tasks:
-    - name: 'Install ansible'
+    - name: 'Install Forklift dependencies'
       package:
-        name: 'ansible'
-        state: 'present'
-
-    - name: 'Install git'
-      package:
-        name: 'git'
+        name:
+          - ansible
+          - git
         state: 'present'
 
     - name: 'Clone Forklift'

--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -4,9 +4,8 @@
 
 - name: "install required packages"
   package:
-    name: "{{ item }}"
+    name: "{{ bats_packages }}"
     state: present
-  with_items: "{{ bats_packages }}"
 
 - name: "Install bats from package"
   package:

--- a/roles/foreman_installer/tasks/packages.yml
+++ b/roles/foreman_installer/tasks/packages.yml
@@ -8,8 +8,7 @@
 
 - name: 'Install additional packages'
   package:
-    name: "{{ item }}"
+    name: "{{ foreman_installer_additional_packages }}"
     state: latest
-  with_items: "{{ foreman_installer_additional_packages }}"
   tags:
     - packages

--- a/roles/libvirt/tasks/main.yml
+++ b/roles/libvirt/tasks/main.yml
@@ -9,9 +9,11 @@
     name: "@Virtualization Tools"
     state: present
 
-- name: 'install the libvirt-python package'
+- name: 'install the libvirt-python support'
   yum:
-    name: "libvirt-python"
+    name:
+      - libvirt-python
+      - python-lxml
     state: present
 
 - name: 'disable libvirt authentication'
@@ -21,14 +23,6 @@
 
 - name: 'restart libvirt'
   service: name=libvirtd state=restarted
-
-- name: 'install libvirt-python dependency'
-  yum:
-    name: libvirt-python
-
-- name: 'install python-lxml'
-  yum:
-    name: python-lxml
 
 - include_tasks: 'tftp.yml'
   when: libvirt_tftp

--- a/roles/powerdns/tasks/main.yml
+++ b/roles/powerdns/tasks/main.yml
@@ -10,11 +10,10 @@
 
 - name: "Install PowerDNS"
   package:
-    name: "{{ item }}"
+    name:
+      - "pdns"
+      - "pdns-backend-mysql"
     state: "present"
-  with_items:
-    - "pdns"
-    - "pdns-backend-mysql"
 
 - name: "Configure PowerDNS"
   template:

--- a/roles/robottelo/tasks/install.yml
+++ b/roles/robottelo/tasks/install.yml
@@ -1,15 +1,14 @@
 ---
 - name: Install packages
   package:
-    name: "{{ item }}"
+    name:
+      - gcc
+      - git
+      - libffi-devel
+      - openssl-devel
+      - rh-python36-python-devel
+      - rh-python36-python-virtualenv
     state: present
-  with_items:
-    - gcc
-    - git
-    - libffi-devel
-    - openssl-devel
-    - rh-python36-python-devel
-    - rh-python36-python-virtualenv
 
 - name: Clone robottelo
   git:

--- a/roles/ruby_scl/tasks/main.yml
+++ b/roles/ruby_scl/tasks/main.yml
@@ -5,11 +5,10 @@
 
 - name: 'Install Ruby SCL'
   yum:
-    name: "{{ item }}"
+    name:
+      - "{{ ruby_scl_version }}"
+      - "{{ ruby_scl_version }}-ruby-devel"
     state: present
-  with_items:
-    - "{{ ruby_scl_version }}"
-    - "{{ ruby_scl_version }}-ruby-devel"
 
 - name: 'Enable SCL at login'
   blockinfile:

--- a/roles/vagrant/tasks/vagrant_libvirt.yml
+++ b/roles/vagrant/tasks/vagrant_libvirt.yml
@@ -1,12 +1,11 @@
 ---
 - name: 'install vagrant-libvirt requirements'
   yum:
-    name: "{{ item }}"
+    name:
+      - libvirt-devel
+      - ruby-devel
+      - gcc
     state: present
-  with_items:
-    - libvirt-devel
-    - ruby-devel
-    - gcc
 
 - name: 'install vagrant-libvirt'
   command: vagrant plugin install vagrant-libvirt


### PR DESCRIPTION
installing packages with a `with_items` loop results in a new package
manager call for each package, which tends to be quite slow.
instead it is recommended to just pass the list of packages to the
`name` attribute of the module, which will then install all packages in
one run