### PR TITLE
Remove myhostname from the foreman meta role

### DIFF
--- a/roles/foreman/meta/main.yml
+++ b/roles/foreman/meta/main.yml
@@ -2,7 +2,6 @@
 dependencies:
   - role: umask
   - role: selinux
-  - role: myhostname
   - role: etc_hosts
   - role: koji
   - role: epel_repositories


### PR DESCRIPTION
The nss-myhostname package isn't used by all ruby scripts because Ruby
doesn't respect NSS if you do direct DNS queries. It's also not always
available so we can remove it.