### PR TITLE
add auto_correct true

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -251,8 +251,8 @@ module Forklift
           override.vm.network :forwarded_port, guest: 3000, host: 3330
           override.vm.network :forwarded_port, guest: 443, host: 4430
         else
-          override.vm.network :forwarded_port, guest: 80, host: 8080
-          override.vm.network :forwarded_port, guest: 443, host: 4433
+          override.vm.network :forwarded_port, guest: 80, host: 8080, auto_correct: true
+          override.vm.network :forwarded_port, guest: 443, host: 4433, auto_correct: true
         end
 
         networks.each do |network|


### PR DESCRIPTION
when using non bridged network with virtual box with multiple VM, thi avoid conflicting port assignement

This helped me when trying to deploy multiVM setup of katello, maybe it is not the right way to do it, feel free to refuse :)