### PR TITLE
simplify version checks in our roles

### DIFF
--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -11,7 +11,7 @@ dependencies:
   - role: foreman_installer
     foreman_installer_scenario: katello
     foreman_installer_options_internal_use_only:
-      - "{{ '--disable-system-checks' if katello_repositories_version != '3.1' else '' }}"
+      - "--disable-system-checks"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
     foreman_installer_additional_packages:
       - katello

--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -47,6 +47,4 @@
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/client/el{{ ansible_distribution_major_version }}/x86_64/"
     priority: 1
     gpgcheck: 0
-  when:
-    - katello_repositories_version != "nightly"
-    - katello_repositories_version|float < 3.9
+  when: katello_repositories_version is version('3.8', '<=')


### PR DESCRIPTION
* Katello 3.1 is unsupported, so just remove that branch
* Use Ansible's version() test instead of casting to float