### PR TITLE
split bats tests into four stages: setup, tests, additional and teardown

### DIFF
--- a/pipelines/pipeline_foreman_nightly.yml
+++ b/pipelines/pipeline_foreman_nightly.yml
@@ -23,6 +23,7 @@
       - "fb-verify-packages.bats"
       - "fb-test-foreman.bats"
       - "fb-test-puppet.bats"
+    bats_teardown:
       - "fb-finish.bats"
   roles:
     - disable_firewall

--- a/pipelines/pipeline_katello_35_to_36_upgrade.yml
+++ b/pipelines/pipeline_katello_35_to_36_upgrade.yml
@@ -73,6 +73,7 @@
     bats_tests:
       - fb-test-katello.bats
       - fb-content-katello.bats
+    bats_teardown: []
   roles:
     - bats
 
@@ -102,6 +103,7 @@
       - fb-destroy-organization.bats
       - fb-content-katello.bats
       - fb-proxy.bats
+    bats_teardown:
       - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_36.yml
+++ b/pipelines/pipeline_katello_36.yml
@@ -72,10 +72,7 @@
 - hosts: pipeline-katello-3.6-centos7
   become: true
   vars:
-    bats_tests:
-      - fb-test-katello.bats
-      - fb-test-puppet.bats
-      - fb-content-katello.bats
+    bats_tests_additional:
       - fb-proxy.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_36.yml
+++ b/pipelines/pipeline_katello_36.yml
@@ -77,7 +77,5 @@
       - fb-test-puppet.bats
       - fb-content-katello.bats
       - fb-proxy.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_36_to_37_upgrade.yml
+++ b/pipelines/pipeline_katello_36_to_37_upgrade.yml
@@ -73,6 +73,7 @@
     bats_tests:
       - fb-test-katello.bats
       - fb-content-katello.bats
+    bats_teardown: []
   roles:
     - bats
 
@@ -104,6 +105,7 @@
       - fb-destroy-organization.bats
       - fb-content-katello.bats
       - fb-proxy.bats
+    bats_teardown:
       - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_37.yml
+++ b/pipelines/pipeline_katello_37.yml
@@ -73,10 +73,7 @@
 - hosts: pipeline-katello-3.7-centos7
   become: true
   vars:
-    bats_tests:
-      - fb-test-katello.bats
-      - fb-test-puppet.bats
-      - fb-content-katello.bats
+    bats_tests_additional:
       - fb-proxy.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_37.yml
+++ b/pipelines/pipeline_katello_37.yml
@@ -78,7 +78,5 @@
       - fb-test-puppet.bats
       - fb-content-katello.bats
       - fb-proxy.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_38.yml
+++ b/pipelines/pipeline_katello_38.yml
@@ -73,10 +73,7 @@
 - hosts: pipeline-katello-3.8-centos7
   become: true
   vars:
-    bats_tests:
-      - fb-test-katello.bats
-      - fb-test-puppet.bats
-      - fb-content-katello.bats
+    bats_tests_additional:
       - fb-proxy.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_38.yml
+++ b/pipelines/pipeline_katello_38.yml
@@ -78,7 +78,5 @@
       - fb-test-puppet.bats
       - fb-content-katello.bats
       - fb-proxy.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_39.yml
+++ b/pipelines/pipeline_katello_39.yml
@@ -81,7 +81,5 @@
       - fb-test-puppet.bats
       - fb-content-katello.bats
       - fb-proxy.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_39.yml
+++ b/pipelines/pipeline_katello_39.yml
@@ -76,10 +76,7 @@
 - hosts: pipeline-katello-3.9-centos7
   become: true
   vars:
-    bats_tests:
-      - fb-test-katello.bats
-      - fb-test-puppet.bats
-      - fb-content-katello.bats
+    bats_tests_additional:
       - fb-proxy.bats
   roles:
     - bats

--- a/pipelines/pipeline_katello_nightly.yml
+++ b/pipelines/pipeline_katello_nightly.yml
@@ -77,10 +77,7 @@
 - hosts: pipeline-katello-nightly-centos7
   become: true
   vars:
-    bats_tests:
-      - fb-verify-packages.bats
-      - fb-test-katello.bats
-      - fb-content-katello.bats
+    bats_tests_additional:
       - fb-proxy.bats
   roles:
     - foreman_testing

--- a/pipelines/pipeline_katello_nightly.yml
+++ b/pipelines/pipeline_katello_nightly.yml
@@ -82,7 +82,5 @@
       - fb-test-katello.bats
       - fb-content-katello.bats
       - fb-proxy.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - foreman_testing

--- a/pipelines/pipeline_katello_upgrade_38.yml
+++ b/pipelines/pipeline_katello_upgrade_38.yml
@@ -62,7 +62,5 @@
     bats_tests:
       - fb-test-katello.bats
       - fb-content-katello.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - foreman_testing

--- a/pipelines/pipeline_katello_upgrade_39.yml
+++ b/pipelines/pipeline_katello_upgrade_39.yml
@@ -85,7 +85,5 @@
     bats_tests:
       - fb-test-katello.bats
       - fb-content-katello.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - foreman_testing

--- a/pipelines/pipeline_katello_upgrade_nightly.yml
+++ b/pipelines/pipeline_katello_upgrade_nightly.yml
@@ -86,7 +86,5 @@
       - fb-verify-packages.bats
       - fb-test-katello.bats
       - fb-content-katello.bats
-      - fb-destroy-organization.bats
-      - fb-finish.bats
   roles:
     - foreman_testing

--- a/pipelines/pipeline_smartproxy_powerdns.yml
+++ b/pipelines/pipeline_smartproxy_powerdns.yml
@@ -15,6 +15,7 @@
     bats_update_forklift: "no"
     bats_tests:
       - "fb-proxy-dns.bats"
+    bats_teardown: []
     foreman_installer_options:
        - "--no-enable-foreman"
        - "--no-enable-foreman-cli"

--- a/playbooks/bats_pipeline_foreman_nightly.yml
+++ b/playbooks/bats_pipeline_foreman_nightly.yml
@@ -12,6 +12,7 @@
       - "fb-verify-packages.bats"
       - "fb-test-foreman.bats"
       - "fb-test-puppet.bats"
+    bats_teardown:
       - "fb-finish.bats"
   roles:
     - disable_firewall

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -22,8 +22,6 @@
       - "fb-test-puppet.bats"
       - "fb-test-katello.bats"
       - "fb-content-katello.bats"
-      - "fb-destroy-organization.bats"
-      - "fb-finish.bats"
   roles:
     - umask
     - selinux

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -16,12 +16,6 @@
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"
       - "--puppet-server-jvm-max-heap-size 1G"
-    bats_tests:
-      - "fb-verify-packages.bats"
-      - "fb-test-foreman.bats"
-      - "fb-test-puppet.bats"
-      - "fb-test-katello.bats"
-      - "fb-content-katello.bats"
   roles:
     - umask
     - selinux

--- a/roles/bats/defaults/main.yaml
+++ b/roles/bats/defaults/main.yaml
@@ -9,11 +9,14 @@ bats_output_dir: "/root/bats_results"
 bats_remote_dir: "/tmp/debug"
 bats_update_forklift: "yes"
 bats_run: true
+bats_setup: []
 bats_tests:
   - "fb-verify-packages.bats"
   - "fb-test-foreman.bats"
   - "fb-test-puppet.bats"
   - "fb-test-katello.bats"
   - "fb-content-katello.bats"
+bats_tests_additional: []
+bats_teardown:
   - "fb-destroy-organization.bats"
   - "fb-finish.bats"

--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -46,7 +46,11 @@
       shell: "bats --tap {{ item }} > {{ bats_output_dir }}/{{ item }}.tap"
       args:
         chdir: "{{ bats_forklift_dir }}/bats"
-      with_items: "{{ bats_tests }}"
+      with_items:
+        - "{{ bats_setup }}"
+        - "{{ bats_tests }}"
+        - "{{ bats_tests_additional }}"
+        - "{{ bats_teardown }}"
       register: "test_output"
       ignore_errors: true
       environment: "{{ bats_environment }}"
@@ -54,7 +58,11 @@
     - name: "Read results"
       shell: "cat {{ bats_output_dir }}/{{ item }}.tap"
       register: "test_results"
-      with_items: "{{ bats_tests }}"
+      with_items:
+        - "{{ bats_setup }}"
+        - "{{ bats_tests }}"
+        - "{{ bats_tests_additional }}"
+        - "{{ bats_teardown }}"
 
     - name: "Output test results"
       debug:


### PR DESCRIPTION
this allows most pipelines to just set "additional" instead of overriding the whole test list