### PR TITLE
make some task/role optional

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,6 @@ nocows = 1
 inventory = $PWD/inventories/
 roles_path = ./playbooks/galaxy_roles:./user_playbooks/roles:./roles
 retry_files_save_path = $HOME/.ansible/retry-files
-remote_user = vagrant
+#remote_user = vagrant
 host_key_checking = False
 force_color = 1

--- a/roles/foreman_installer/tasks/module_prs.yml
+++ b/roles/foreman_installer/tasks/module_prs.yml
@@ -10,7 +10,7 @@
     executable: /opt/puppetlabs/puppet/bin/gem
   with_items:
     - puppet-strings
-  when: puppetlabs_gem.stat.exists
+  when: ( puppetlabs_gem.stat.exists and determine_puppetlabs_gem_check is not defined )
   tags:
     - packages
 

--- a/roles/foreman_installer/tasks/module_prs.yml
+++ b/roles/foreman_installer/tasks/module_prs.yml
@@ -10,7 +10,7 @@
     executable: /opt/puppetlabs/puppet/bin/gem
   with_items:
     - puppet-strings
-  when: ( puppetlabs_gem.stat.exists and determine_puppetlabs_gem_check is not defined )
+  when: puppetlabs_gem.stat.exists
   tags:
     - packages
 

--- a/roles/ostree_repositories/defaults/main.yml
+++ b/roles/ostree_repositories/defaults/main.yml
@@ -1,0 +1,1 @@
+ostree_repositories_enabled: yes

--- a/roles/ostree_repositories/tasks/main.yml
+++ b/roles/ostree_repositories/tasks/main.yml
@@ -5,4 +5,4 @@
     description: Centos Atomic Build Repository
     baseurl: http://buildlogs.centos.org/centos/7/atomic/x86_64/Packages/
     gpgcheck: no
-  when: no_ostree_repo is not defined
+    enabled : "{{ ostree_repositories_enabled }}"

--- a/roles/ostree_repositories/tasks/main.yml
+++ b/roles/ostree_repositories/tasks/main.yml
@@ -5,3 +5,4 @@
     description: Centos Atomic Build Repository
     baseurl: http://buildlogs.centos.org/centos/7/atomic/x86_64/Packages/
     gpgcheck: no
+  when: no_ostree_repo is not defined


### PR DESCRIPTION
Here is a small workaround that i add to ease the deploy of a production box
I figure out that i didn't need the following:
- Atomic repo
- puppet-strings gem
- the hardcoded vagrant user in Ansible config (i believe vagrant handle that himself, and it is not necessary)

This is probably not the right way to do it, feel free to propose something so I can refactor it the right way
Regards
Mike