### PR TITLE
Make version compare handle nightly

### DIFF
--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -47,4 +47,6 @@
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/client/el{{ ansible_distribution_major_version }}/x86_64/"
     priority: 1
     gpgcheck: 0
-  when: katello_repositories_version is version('3.8', '<=')
+  when:
+    - katello_repositories_version != "nightly"
+    - katello_repositories_version is version('3.8', '<=')


### PR DESCRIPTION
The prior code for 'Katello Client Koji repository' did not check for
the nightly causing the following error
""""
The conditional check
'katello_repositories_version is version('3.8', '<=')'
failed. The error was:
Version comparison: '<' not supported between instances of
'str' and 'int'
""""