### PR TITLE
Check if module_prs or module_branches are non-empty

### DIFF
--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -5,7 +5,7 @@
   when: ansible_os_family == 'Debian'
 
 - include_tasks: module_prs.yml
-  when: foreman_installer_module_prs != "" or foreman_installer_module_branches != ""
+  when: (foreman_installer_module_prs|length > 0) or (foreman_installer_module_branches|length > 0)
 
 - include_tasks: custom_hiera.yml
   when: foreman_installer_custom_hiera != ""


### PR DESCRIPTION
9866483b1e50af65ffbcfb9beeff628dd80ef39f changed the defaults to arrays.
This change ensures we only include the tasks when it's needed.