### PR TITLE
Separate libvirt playbook

### DIFF
--- a/playbooks/libvirt.yml
+++ b/playbooks/libvirt.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  become: true
+  vars:
+    libvirt_tftp: true
+  roles:
+    - libvirt

--- a/roles/libvirt/defaults/main.yml
+++ b/roles/libvirt/defaults/main.yml
@@ -4,3 +4,4 @@ libvirt_setup_dhcp_start: 192.168.73.2
 libvirt_setup_dhcp_end: 192.168.73.254
 libvirt_setup_storage_path: /var/lib/libvirt/images
 libvirt_tftp: false
+libvirt_nested: false

--- a/roles/libvirt/tasks/main.yml
+++ b/roles/libvirt/tasks/main.yml
@@ -21,6 +21,9 @@
     dest: /etc/libvirt/libvirtd.conf
     line: 'auth_unix_rw = "none"'
 
+- include_tasks: 'nested.yml'
+  when: libvirt_nested
+
 - name: 'restart libvirt'
   service: name=libvirtd state=restarted
 

--- a/roles/libvirt/tasks/nested.yml
+++ b/roles/libvirt/tasks/nested.yml
@@ -1,0 +1,15 @@
+- name: 'check if Intel or AMD processor'
+  shell: "grep -q Intel /proc/cpuinfo && echo -n 'intel' || echo -n 'amd'"
+  ignore_errors: true
+  register: cpu_type
+
+- name: 'rmmod kvm'
+  command: "modprobe -r kvm_{{ cpu_type.stdout }}"
+
+- name: 'enable nested virtualization'
+  copy:
+    dest: /etc/modprobe.d/kvm.conf
+    content: "options kvm_{{ cpu_type.stdout }} nested=1"
+
+- name: 'insmod kvm with nested'
+  command: "modprobe kvm_{{ cpu_type.stdout }} nested=1"


### PR DESCRIPTION
This adds the ability to enable nested virt on a VM, and also creates a standalone libvirt playbook.  I tend to run this playbook on dev boxes when I want to enable provisioning. I'd like to have a dev provisioning playbook entirely, but there's a bunch of issues to fix before we can get there easily