### PR TITLE
Allow insecure sub-man register for kat-client

### DIFF
--- a/roles/katello_client/defaults/main.yml
+++ b/roles/katello_client/defaults/main.yml
@@ -6,5 +6,6 @@ katello_client_username: "admin"
 katello_client_password: "changeme"
 katello_client_activationkey: ""
 katello_client_extra_repos: []
+katello_client_insecure: False
 katello_client_install_agent: False
 katello_client_install_tracer: False

--- a/roles/katello_client/tasks/main.yml
+++ b/roles/katello_client/tasks/main.yml
@@ -15,6 +15,7 @@
     environment: "{{ katello_client_environment }}"
     username: "{{ katello_client_username }}"
     password: "{{ katello_client_password }}"
+    server_insecure: "{{ katello_client_insecure }}"
   when:
     - katello_client_activationkey == ""
 
@@ -23,6 +24,7 @@
     state: "present"
     org_id: "{{ katello_client_organization }}"
     activationkey: "{{ katello_client_activationkey }}"
+    server_insecure: "{{ katello_client_insecure }}"
   when:
     - katello_client_activationkey != ""
 


### PR DESCRIPTION
To test:

```yaml
centos7-katello-client:
  box: centos7
  ansible:
    playbook: 'playbooks/katello_client.yml'
    group: 'client'
    variables:
      katello_client_insecure: True
      katello_client_server: 'centos7-devel'

# with an activation key
centos7-katello-client:
  box: centos7
  ansible:
    playbook: 'playbooks/katello_client.yml'
    group: 'client'
    variables:
      katello_client_insecure: True
      katello_client_server: 'centos7-devel'
      katello_client_activationkey: 'ak1'
```