### PR TITLE
[WIP] obalize the pipelines

### DIFF
--- a/bin/forklift
+++ b/bin/forklift
@@ -1,0 +1,5 @@
+#!/bin/sh
+export OBAL_DATA="$(dirname $(dirname $(realpath $0)))"
+export OBAL_PLAYBOOKS="${OBAL_DATA}/pipelines"
+export OBAL_INVENTORY="${OBAL_DATA}/inventories"
+exec obal "$@"

--- a/pipelines/katello_pipeline/katello_pipeline.yaml
+++ b/pipelines/katello_pipeline/katello_pipeline.yaml
@@ -1,7 +1,7 @@
 - hosts: localhost
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_{{ katello_version }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_{{ katello_version }}.yml
   roles:
     - forklift
 
@@ -12,9 +12,9 @@
   vars:
     foreman_installer_skip_installer: true
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_base_staging.yml
-    - vars/katello_{{ katello_version }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_base_staging.yml
+    - ../vars/katello_{{ katello_version }}.yml
   roles:
     - role: disable_firewall
     - role: disable_ipv6
@@ -29,9 +29,9 @@
 - hosts: pipeline-katello-{{ katello_version }}-centos7
   become: yes
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_base_staging.yml
-    - vars/katello_{{ katello_version }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_base_staging.yml
+    - ../vars/katello_{{ katello_version }}.yml
   roles:
     - foreman_installer
 
@@ -52,7 +52,7 @@
       - "--foreman-proxy-content-parent-fqdn {{ server_fqdn.stdout }}"
       - "--puppet-server-foreman-url https://{{ server_fqdn.stdout }}"
   vars_files:
-    - vars/katello_{{ katello_version }}.yml
+    - ../vars/katello_{{ katello_version }}.yml
   roles:
     - foreman_proxy_content
     - foreman_installer
@@ -63,8 +63,8 @@
     bats_tests_additional:
       - fb-proxy.bats
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_{{ katello_version }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_{{ katello_version }}.yml
   roles:
     - role: foreman_testing
       when: pipeline_run_tests

--- a/pipelines/katello_pipeline/metadata.obal.yaml
+++ b/pipelines/katello_pipeline/metadata.obal.yaml
@@ -1,0 +1,7 @@
+help: >
+  Perform a Katello installation with a separate proxy and run tests on it
+variables:
+  katello_version:
+    help: The Katello version
+  forklift_state:
+    help: The state of the machines to ensure

--- a/pipelines/katello_upgrade_pipeline/katello_upgrade_pipeline.yaml
+++ b/pipelines/katello_upgrade_pipeline/katello_upgrade_pipeline.yaml
@@ -1,6 +1,6 @@
 - hosts: localhost
   vars_files:
-    - vars/katello_base.yml
+    - ../vars/katello_base.yml
   vars:
     forklift_name: pipeline-upgrade-nightly
     forklift_boxes:
@@ -12,10 +12,10 @@
   become: yes
   vars:
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_base_release.yml
-    - vars/katello_upgrade_{{ katello_version }}.yml
-    - vars/katello_{{ katello_version_start }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_base_release.yml
+    - ../vars/katello_upgrade_{{ katello_version }}.yml
+    - ../vars/katello_{{ katello_version_start }}.yml
   roles:
     - umask
     - selinux
@@ -31,10 +31,10 @@
 - hosts: pipeline-upgrade-centos7
   become: true
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_base_release.yml
-    - vars/katello_upgrade_{{ katello_version }}.yml
-    - vars/katello_{{ katello_version_intermediate }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_base_release.yml
+    - ../vars/katello_upgrade_{{ katello_version }}.yml
+    - ../vars/katello_{{ katello_version_intermediate }}.yml
   vars:
     foreman_installer_upgrade: True
     foreman_installer_skip_installer: "{{ true if katello_version_start == katello_version_intermediate else false }}"
@@ -49,10 +49,10 @@
   vars:
     foreman_installer_upgrade: True
   vars_files:
-    - vars/katello_base.yml
-    - vars/katello_base_staging.yml
-    - vars/katello_upgrade_{{ katello_version }}.yml
-    - vars/katello_{{ katello_version_final }}.yml
+    - ../vars/katello_base.yml
+    - ../vars/katello_base_staging.yml
+    - ../vars/katello_upgrade_{{ katello_version }}.yml
+    - ../vars/katello_{{ katello_version_final }}.yml
   roles:
     - foreman_server_repositories
     - role: foreman_client_repositories
@@ -62,7 +62,7 @@
 - hosts: pipeline-upgrade-centos7
   become: yes
   vars_files:
-    - vars/katello_upgrade_{{ katello_version }}.yml
-    - vars/katello_{{ katello_version_final }}.yml
+    - ../vars/katello_upgrade_{{ katello_version }}.yml
+    - ../vars/katello_{{ katello_version_final }}.yml
   roles:
     - foreman_testing

--- a/pipelines/katello_upgrade_pipeline/metadata.obal.yaml
+++ b/pipelines/katello_upgrade_pipeline/metadata.obal.yaml
@@ -1,0 +1,12 @@
+help: >
+  Perform a Katello upgrade pipeline
+
+
+  This pipeline installs a base version, then upgrades it to an intermediate
+  version. Lastly it's upgraded to the final version (the katello_version
+  parameter) and tests are ran on that.
+variables:
+  katello_version:
+    help: The Katello version to run tests on.
+  forklift_state:
+    help: The state of the machines to ensure


### PR DESCRIPTION
Requires https://github.com/theforeman/obal/pull/169

Looks like we do need to override the prog (which we now hardcode), but the idea is:

```
$ ./bin/forklift --help
usage: obal [-h] action ...

positional arguments:
  action                which action to execute
    katello_pipeline    Perform a Katello installation with a separate proxy
                        and run tests on it
    katello_upgrade_pipeline
                        Perform a Katello upgrade pipeline

optional arguments:
  -h, --help            show this help message and exit
```

```
$ ./bin/forklift katello_pipeline --help
usage: obal katello_pipeline [-h] [-v] [-e EXTRA_VARS]
                             [--forklift-state FORKLIFT_STATE]
                             [--katello-version KATELLO_VERSION]

Perform a Katello installation with a separate proxy and run tests on it

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         verbose output
  --forklift-state FORKLIFT_STATE
                        The state of the machines to ensure
  --katello-version KATELLO_VERSION
                        The Katello version

advanced arguments:
  -e EXTRA_VARS, --extra-vars EXTRA_VARS
                        set additional variables as key=value or YAML/JSON, if
                        filename prepend with @
```