### PR TITLE
use playbook_dir instead of role_path for forklift_directory

### DIFF
--- a/roles/forklift/defaults/main.yml
+++ b/roles/forklift/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-forklift_directory: "{{ role_path | dirname | dirname }}"
+forklift_directory: "{{ playbook_dir | dirname }}"
 forklift_state: ''


### PR DESCRIPTION
`forklift_directory` is used to determine where to write the temporary
vagrant files to.
Using `role_path` works fine inside of `forklift` itself, but sadly
breaks if `forklift` is used as a library (e.g. in `pulplift`) where the
roles end up in `<project>/forklift/roles` and thus the vagrant files
would be written to `<project>/forklift/vagrant/boxes.d` instead of
`<project>/vagrant/boxes.d`.
As both `forklift` and `pulplift` put their specific playbooks into a
subdir, we can set `forklift_directory` to `playbook_dir | dirname` and
then the vagrant files end up in the right subfolder.