### PR TITLE
Always use taxonomies in forman_provisioning playbook

### DIFF
--- a/roles/foreman_provisioning/defaults/main.yml
+++ b/roles/foreman_provisioning/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 foreman_provisioning_scenario: ''
 foreman_provisioning_hammer: hammer
-foreman_provisioning_use_taxonomies: False
 foreman_provisioning_organization: Default Organization
 foreman_provisioning_location: Default Location
 foreman_provisioning_proxy_name: "{{ ansible_fqdn }}"

--- a/roles/foreman_provisioning/tasks/main.yml
+++ b/roles/foreman_provisioning/tasks/main.yml
@@ -1,21 +1,4 @@
 ---
-# make installation media available
-# until it's done by seed - http://projects.theforeman.org/issues/22661
-- name: 'assign organization and location to all seeded media'
-  with_items:
-    - CentOS mirror
-    - CoreOS mirror
-    - Debian mirror
-    - Fedora Atomic mirror
-    - Fedora mirror
-    - FreeBSD mirror
-    - OpenSUSE mirror
-    - Ubuntu mirror
-  shell: >
-    {{ foreman_provisioning_hammer }} medium update --name "{{ item }}" --organization-titles "{{ foreman_provisioning_organization }}" --location-titles "{{ foreman_provisioning_location }}"
-  when: foreman_provisioning_use_taxonomies and foreman_provisioning_foreman_version == 'nightly'
-
-
 - name: 'Setup CentOS 7 provisioning'
   import_tasks: configure_centos_7.yml
 

--- a/roles/foreman_provisioning_infrastructure/tasks/main.yml
+++ b/roles/foreman_provisioning_infrastructure/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: 'disable default context for admin'
   shell: >
     {{ foreman_provisioning_hammer }} user update --login admin --default-organization-id 0 --default-location-id 0
-  when: foreman_provisioning_use_taxonomies
 
 # Get the smart proxy ID of the local katello:
 - name: 'get smart proxy id'
@@ -22,12 +21,10 @@
 - name: 'prepare hammer taxonomy options'
   set_fact:
     foreman_provisioning_hammer_taxonomy_params: "--organizations '{{ foreman_provisioning_organization }}' --locations '{{ foreman_provisioning_location }}'"
-  when: foreman_provisioning_use_taxonomies
 
-- name: 'prepare blank hammer taxonomy options'
-  set_fact:
-    foreman_provisioning_hammer_taxonomy_params: ""
-  when: not foreman_provisioning_use_taxonomies
+- name: 'Set taxonomies for proxy'
+  shell: >
+    {{ foreman_provisioning_hammer }} proxy update --id {{ foreman_provisioning_smart_proxy.Id }} {{ foreman_provisioning_hammer_taxonomy_params }}
 
 # Compute Resource
 - name: 'find compute resource'


### PR DESCRIPTION
Foreman now installs with taxonomies enabled, so we need to make sure resources are assigned to org/loc.