### PR TITLE
Do not use external nameservers in ubuntu 16.04

### DIFF
--- a/vagrant/boxes.d/00-ubuntu.yaml
+++ b/vagrant/boxes.d/00-ubuntu.yaml
@@ -5,6 +5,10 @@ boxes:
     pty: true
     scenarios:
       - foreman
+    shell:
+      # Work around external nameservers in generic/ubuntu1604
+      # https://github.com/lavabit/robox/issues/11
+      sed -i 's/allow-hotplug eth0/auto eth0/ ; /^dns-nameserver/d ; /^pre-up sleep 2$/d' /etc/network/interfaces && systemctl restart networking
     ansible:
       variables:
         ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
The corporate network here doesn't allow usage of external nameservers.  The generic/ubuntu1604 image configures 3 external nameservers so the DHCP provides ones are never used (glibc limitation). This workaround ensures we don't use them.

This isn't an issue with generic/ubuntu1804 because that uses systemd-resolved which properly detects it can't reach the external nameservers and stops querying them, gracefully falling back to the DHCP provides ones.