### PR TITLE
don't check if katello_version is a number, it isn't

### DIFF
--- a/pipelines/katello_pipeline.yml
+++ b/pipelines/katello_pipeline.yml
@@ -22,7 +22,7 @@
       foreman_server_repositories_katello_client: katello_version == 'nightly' or katello_version is number and katello_version is version('3.9', '>=') | bool
     - role: update_os_packages
     - role: katello
-      when: katello_version is number or katello_version == "nightly"
+      when: katello_version != "devel"
     - role: katello_devel
       when: katello_version == "devel"
 


### PR DESCRIPTION
when you pass variables to ansible on the shell, they are always
interpreted as strings:

    % ansible -m debug -a 'msg={{ katello_version is number }}' -e katello_version=3.10 localhost
    localhost | SUCCESS => {
        "msg": false
    }

therefor always include the katello role when katello_version is not
"devel"