### PR TITLE
Use bundler from scl (< 2.0), not rubygems (> 2.0)

### DIFF
--- a/roles/hammer_devel/tasks/hammer_install.yml
+++ b/roles/hammer_devel/tasks/hammer_install.yml
@@ -50,8 +50,5 @@
   become: true
   yum: name=gcc-c++ state=present
 
-- name: 'Install bundler'
-  gem: name=bundler state=present
-
 - name: 'Install gems'
-  bundler: chdir=~/hammer-cli-foreman state=present executable=~/bin/bundle
+  bundler: chdir=~/hammer-cli-foreman state=present

--- a/roles/ruby_scl/tasks/main.yml
+++ b/roles/ruby_scl/tasks/main.yml
@@ -8,6 +8,7 @@
     name:
       - "{{ ruby_scl_version }}"
       - "{{ ruby_scl_version }}-ruby-devel"
+      - "{{ ruby_scl_version }}-rubygem-bundler"
     state: present
 
 - name: 'Enable SCL at login'


### PR DESCRIPTION
The scl ships a specific version of rubygems and bundler. When we install
bundler with rubygems, we get a version (>2.0) that isn't supported with the installed version of rubygems (< 3.0).