### PR TITLE
Support using fqdn as inventory name in etc_hosts

### DIFF
--- a/roles/etc_hosts/tasks/hosts_file_record.yml
+++ b/roles/etc_hosts/tasks/hosts_file_record.yml
@@ -1,0 +1,27 @@
+---
+# expected vars:
+#  * ip
+#  * hostname
+#  * domain
+
+# the domain is not included in the hostname
+- name: "Add {{ hostname }} to hosts file: short and full"
+  lineinfile:
+    dest: /etc/hosts
+    regexp: ".*{{ hostname.replace('.', '-') }}$"
+    line: "{{ ip }} {{ hostname.replace('.', '-') }}.{{ domain }} {{ hostname.replace('.', '-') }}"
+    state: present
+  when: not hostname | regex_search(domain | regex_escape())
+  become: yes
+  tags: env_setup
+
+# the domain is part of the hostname
+- name: "Add {{ hostname }} to hosts file: full only"
+  lineinfile:
+    dest: /etc/hosts
+    regexp: ".*{{ hostname }}$"
+    line: "{{ ip }} {{ hostname }}"
+    state: present
+  when: hostname | regex_search(domain | regex_escape())
+  become: yes
+  tags: env_setup

--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: "Build hosts file"
-  lineinfile:
-    dest: /etc/hosts
-    regexp: ".*{{ item.replace('.', '-') }}$"
-    line: "{{ hostvars[item].ansible_host }} {{ item.replace('.', '-') }}.{{ etc_hosts_domain }} {{ item.replace('.', '-') }}"
-    state: present
+  include_tasks: "./hosts_file_record.yml"
+  vars:
+    ip: "{{ hostvars[item].ansible_host }}"
+    domain: "{{ etc_hosts_domain }}"
+    hostname: "{{ item }}"
   when: hostvars[item].ansible_host is defined
   become: yes
   with_items: "{{ groups['all'] }}"


### PR DESCRIPTION
I'm using fqdn as inventory name for my hosts. Before this patch, I was
ending with etc hosts like this:

   1.2.3.4 my-host-example-com.example.com my-host-example-com

This was because the `etc_hosts` role haven't expected fqdn in inventory
name. After this patch, both short and long names in inventory are
supported.