### PR TITLE
Make instructions BSD-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The same can be quickly done for a development environment where GITHUB_NICK is 
 git clone https://github.com/theforeman/forklift.git
 cd forklift
 cp vagrant/boxes.d/99-local.yaml.example vagrant/boxes.d/99-local.yaml
-sed -i "s/<REPLACE ME>/GITHUB_NICK/g" vagrant/boxes.d/99-local.yaml
+sed -i.bak "s/<REPLACE ME>/GITHUB_NICK/g" vagrant/boxes.d/99-local.yaml
 vagrant up centos7-katello-devel
 ```
 


### PR DESCRIPTION
People with macOS could struggle because BSD sed require backup extension to be present when doing inplace replace. Weird behavior indeed. This works fine with both and according to stackoverflow it is the most portable way of seding.