### PR TITLE
Ensure puppet5-release is absent when installing puppet6

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,7 @@ When you are finished with the test, you can tear down the associated infrastruc
 #### Examples
 
     ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=debian9 -e pipeline_type=foreman -e pipeline_version=nightly
-    ansible-playbook pipelines/update_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
+    ansible-playbook pipelines/upgrade_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
 
 ### Creating Pipelines
 

--- a/roles/puppet_repositories/tasks/puppetlabs-6-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-6-redhat.yml
@@ -1,4 +1,11 @@
 ---
+- name: 'Remove Puppet 5 Repository'
+  yum:
+    name: puppet5-release
+    state: absent
+  tags:
+    - packages
+
 - name: 'Setup Puppet 6 Repository'
   yum:
     name: https://yum.puppetlabs.com/puppet6/puppet6-release-el-{{ ansible_distribution_major_version }}.noarch.rpm


### PR DESCRIPTION
The puppet6-release package conflicts with puppet5. This ensures we can upgrade.