### PR TITLE
Fixes #950 - Make luna-devel install plugins again

### DIFF
--- a/roles/katello/defaults/main.yml
+++ b/roles/katello/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+foreman_server_repositories_katello: true
+foreman_server_repositories_ostree: true
+foreman_installer_scenario: katello
+foreman_installer_options_internal_use_only:
+  - --disable-system-checks
+  - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
+foreman_installer_additional_packages:
+  - katello

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -1,11 +1,3 @@
 ---
 dependencies:
   - role: foreman
-    foreman_server_repositories_katello: true
-    foreman_server_repositories_ostree: true
-    foreman_installer_scenario: katello
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
-    foreman_installer_additional_packages:
-      - katello

--- a/roles/katello_devel/defaults/main.yml
+++ b/roles/katello_devel/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+foreman_installer_options_internal_use_only:
+  - --disable-system-checks
+  - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
+  - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -12,7 +12,3 @@ dependencies:
     foreman_installer_scenario: katello-devel
     foreman_installer_additional_packages:
       - foreman-installer-katello
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
-      - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
-      - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"


### PR DESCRIPTION
Move foreman_installer_options_internal_use_only to vars, so it can be overwritten by value specified in playbooks/luna-devel.yml.