### PR TITLE
Use yaml.safe_load in box-downloader

### DIFF
--- a/bin/box-downloader
+++ b/bin/box-downloader
@@ -27,7 +27,7 @@ def download(url):
             click.echo('Downloading {} to {}'.format(filename, target))
             fp.write(response.content)
 
-            boxes = yaml.load(response.content)
+            boxes = yaml.safe_load(response.content)
             click.echo('Found boxes: {}'.format(' '.join(boxes.keys())))
 
 


### PR DESCRIPTION
Plain yaml.load raises a warning and since we only use simple data types, safe_load is sufficient for our needs.