### PR TITLE
Switch pulp in nightly to 2.19

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -59,7 +59,7 @@ installers:
 
   - foreman: 'nightly'
     katello: 'nightly'
-    pulp: 'nightly'
+    pulp: '2.19'
     puppet: 6
     boxes:
       - 'centos7'


### PR DESCRIPTION
Pulp 2 nightly streamer currently fails, but it's not present in 2.19.

https://pulp.plan.io/issues/4649