### PR TITLE
Fix katello-devel and luna

### DIFF
--- a/playbooks/luna-devel.yml
+++ b/playbooks/luna-devel.yml
@@ -1,16 +1,29 @@
 ---
-- import_playbook: katello_devel.yml
-  vars:
-    katello_devel_github_username: ''
-    foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
-      - "--katello-devel-github-username '{{ katello_devel_github_username }}'"
-      - "--katello-devel-enable-ostree=true"
-      - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
-      - "--katello-devel-extra-plugins theforeman/foreman_discovery"
-      - "--katello-devel-extra-plugins theforeman/foreman_ansible"
-      - "--katello-devel-extra-plugins theforeman/foreman-tasks"
-      - "--katello-devel-extra-plugins theforeman/foreman_bootdisk"
-      - "--katello-devel-extra-plugins theforeman/foreman_openscap"
-      - "--katello-devel-extra-plugins theforeman/foreman_templates"
-      - "--katello-devel-extra-plugins theforeman/foreman_hooks"
+- hosts: all
+  become: true
+  roles:
+    - role: etc_hosts
+    - role: foreman_server_repositories
+      foreman_server_repositories_ostree: true
+      foreman_server_repositories_katello: true
+      foreman_server_repositories_foreman_client: true
+    - role: ruby_scl
+    - role: foreman_installer_devel_scenario
+    - role: foreman_installer
+      katello_repositories_version: nightly
+      foreman_installer_scenario: katello-devel
+      katello_devel_github_username: ''
+      foreman_installer_options_internal_use_only:
+        - "--disable-system-checks"
+        - "--katello-devel-github-username '{{ katello_devel_github_username }}'"
+        - "--katello-devel-enable-ostree=true"
+        - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
+        - "--katello-devel-extra-plugins theforeman/foreman_discovery"
+        - "--katello-devel-extra-plugins theforeman/foreman_ansible"
+        - "--katello-devel-extra-plugins theforeman/foreman-tasks"
+        - "--katello-devel-extra-plugins theforeman/foreman_bootdisk"
+        - "--katello-devel-extra-plugins theforeman/foreman_openscap"
+        - "--katello-devel-extra-plugins theforeman/foreman_templates"
+        - "--katello-devel-extra-plugins theforeman/foreman_hooks"
+      foreman_installer_additional_packages:
+        - foreman-installer-katello

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -3,8 +3,6 @@
   become: true
   vars:
     foreman_installer_options:
-      - "--disable-system-checks"
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--enable-foreman-plugin-ansible"
       - "--enable-foreman-plugin-discovery"
       - "--enable-foreman-plugin-bootdisk"
@@ -22,6 +20,7 @@
       - "--enable-foreman-cli-tasks"
       - "--enable-foreman-cli-templates"
     foreman_installer_additional_packages:
+      - katello
       - tfm-rubygem-foreman_virt_who_configure
       - tfm-rubygem-hammer_cli_foreman_virt_who_configure
   roles:

--- a/roles/katello/defaults/main.yml
+++ b/roles/katello/defaults/main.yml
@@ -1,9 +1,0 @@
----
-foreman_server_repositories_katello: true
-foreman_server_repositories_ostree: true
-foreman_installer_scenario: katello
-foreman_installer_options_internal_use_only:
-  - --disable-system-checks
-  - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
-foreman_installer_additional_packages:
-  - katello

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -1,3 +1,11 @@
 ---
 dependencies:
   - role: foreman
+    foreman_server_repositories_katello: true
+    foreman_server_repositories_ostree: true
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
+    foreman_installer_additional_packages:
+      - katello

--- a/roles/katello_devel/defaults/main.yml
+++ b/roles/katello_devel/defaults/main.yml
@@ -1,5 +1,0 @@
----
-foreman_installer_options_internal_use_only:
-  - --disable-system-checks
-  - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
-  - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -12,3 +12,7 @@ dependencies:
     foreman_installer_scenario: katello-devel
     foreman_installer_additional_packages:
       - foreman-installer-katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
+      - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"


### PR DESCRIPTION
Turns out PR #951 broke centos7-katello-devel boxes.

As far as I understand, the problem is in a way Ansible variable precedence works. When variable is defined at role parameter level, it takes precedence over almost everything. But when it is put in `defaults/main.yml` of role, then almost everything takes precedence over it - including `defaults` of dependent roles.

So we can have foreman installer options defined in `defaults` for `katello_devel`, which makes luna playbooks work, but katello-devel fail; or we can have it defined in katello_devel roles params, which makes katello-devel work, but also makes it impossible to override variables at playbook level and breaks luna.

This PR reverts 596ac89e8b5d015b88890bad5c2be41bcc56dd4b and takes another approach at luna playbooks - instead of including katello role, it duplicates it and adds variables as parameters. Main drawback is that we have some roles duplicated, but it seems to actually work this time.

I'm not huge fan of this solution, but this is about as far as my Ansible can take me. If there is better approach, I'm willing to implement it, but I need to be pointed in the right direction.