### PR TITLE
Update puppet_repositories to new layout

### DIFF
--- a/roles/puppet_repositories/tasks/puppetlabs-3-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-3-redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup Puppet 3 Repository'
   yum:
-    name: https://yum.puppetlabs.com/puppetlabs-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://release-archives.puppet.com/yum/puppetlabs-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
   tags:
     - packages

--- a/roles/puppet_repositories/tasks/puppetlabs-4-debian.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-4-debian.yml
@@ -1,9 +1,9 @@
 ---
-- name: 'Install Puppetlabs GPG key'
+- name: 'Install Puppet GPG key'
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    url: https://apt.puppet.com/DEB-GPG-KEY-puppet
 
-- name: 'Install Puppetlabs PC1 repository'
+- name: 'Install Puppet PC1 repository'
   apt_repository:
-    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} PC1
+    repo: deb http://apt.puppet.com {{ ansible_distribution_release }} PC1
     state: present

--- a/roles/puppet_repositories/tasks/puppetlabs-4-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-4-redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup Puppet 4 Repository'
   yum:
-    name: https://yum.puppetlabs.com/puppetlabs-release-pc1-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://release-archives.puppet.com/yum/puppetlabs-release-pc1-el-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
   tags:
     - packages

--- a/roles/puppet_repositories/tasks/puppetlabs-5-debian.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-5-debian.yml
@@ -1,11 +1,11 @@
 ---
-- name: 'Install Puppetlabs GPG key'
+- name: 'Install Puppet GPG key'
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    url: https://apt.puppet.com/DEB-GPG-KEY-puppet
 
-- name: 'Install Puppetlabs Puppet 5 repository'
+- name: 'Install Puppet 5 repository'
   apt_repository:
-    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} puppet5
+    repo: deb http://apt.puppet.com {{ ansible_distribution_release }} puppet5
     state: present
 
 - name: 'Install backports'

--- a/roles/puppet_repositories/tasks/puppetlabs-5-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-5-redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup Puppet 5 Repository'
   yum:
-    name: https://yum.puppetlabs.com/puppet5/puppet5-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://yum.puppet.com/puppet5-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
   tags:
     - packages

--- a/roles/puppet_repositories/tasks/puppetlabs-6-debian.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-6-debian.yml
@@ -1,9 +1,9 @@
 ---
-- name: 'Install Puppetlabs GPG key'
+- name: 'Install Puppet GPG key'
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    url: https://apt.puppet.com/DEB-GPG-KEY-puppet
 
-- name: 'Install Puppetlabs Puppet 6 repository'
+- name: 'Install Puppet 6 repository'
   apt_repository:
-    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} puppet6
+    repo: deb http://apt.puppet.com {{ ansible_distribution_release }} puppet6
     state: present

--- a/roles/puppet_repositories/tasks/puppetlabs-6-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-6-redhat.yml
@@ -8,7 +8,7 @@
 
 - name: 'Setup Puppet 6 Repository'
   yum:
-    name: https://yum.puppetlabs.com/puppet6/puppet6-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://yum.puppet.com/puppet6-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
   tags:
     - packages

--- a/roles/puppet_repositories/tasks/puppetlabs-nightly-debian.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-nightly-debian.yml
@@ -1,11 +1,11 @@
 ---
-- name: 'Install Puppetlabs GPG key'
+- name: 'Install Puppet GPG key'
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    url: https://apt.puppet.com/DEB-GPG-KEY-puppet
 
-- name: 'Install Puppetlabs Puppet 5 Nightly repository'
+- name: 'Install Puppet 6 Nightly repository'
   apt_repository:
-    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} puppet5-nightly
+    repo: deb http://apt.puppetlabs.com {{ ansible_distribution_release }} puppet6-nightly
     state: present
 
 - name: 'Install backports'

--- a/roles/puppet_repositories/tasks/puppetlabs-nightly-redhat.yml
+++ b/roles/puppet_repositories/tasks/puppetlabs-nightly-redhat.yml
@@ -1,7 +1,7 @@
 ---
-- name: 'Setup Puppet 5 Nightly Repository'
+- name: 'Setup Puppet 6 Nightly Repository'
   yum:
-    name: https://yum.puppetlabs.com/puppet5/puppet5-nightly/puppet5-nightly-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://yum.puppet.com/puppet6-nightly-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
   tags:
     - packages


### PR DESCRIPTION
The Puppet repositories are moving around. Current releases are moved to the topp level while all release-archives.puppet.com is now used for EOL releases.

See https://groups.google.com/forum/#!topic/puppet-dev/19brLt5MuDw for the official announcement.