### PR TITLE
Install correct repos on katello-client box

### DIFF
--- a/playbooks/katello_client.yml
+++ b/playbooks/katello_client.yml
@@ -6,5 +6,5 @@
   roles:
     - etc_hosts
     - epel_repositories
-    - katello_repositories
+    - foreman_client_repositories
     - katello_client


### PR DESCRIPTION
katello-host-tools isn't installable without this