### PR TITLE
Update bundler to fix gem installation

### DIFF
--- a/roles/hammer_devel/tasks/hammer_install.yml
+++ b/roles/hammer_devel/tasks/hammer_install.yml
@@ -50,5 +50,10 @@
   become: true
   yum: name=gcc-c++ state=present
 
+- name: 'Update bundler'
+  gem:
+    name: bundler
+    state: latest
+
 - name: 'Install gems'
   bundler: chdir=~/hammer-cli-foreman state=present


### PR DESCRIPTION
I'm not really sure if this is the Right Way to fix this environment, but the following is currently happening when bringing up the centos7-hammer-devel box:

```
[vagrant@centos7-hammer-devel hammer-cli-foreman]$ bundle
Traceback (most recent call last):
        2: from /opt/rh/rh-ruby25/root/usr/bin/bundle:23:in `<main>'
        1: from /opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems.rb:308:in `activate_bin_path'
/opt/rh/rh-ruby25/root/usr/share/rubygems/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```

This command executes the version of bundler shipped with rh-ruby25, rh-ruby25-rubygem-bundler-1.16.1-1.el7.noarch, but the version of rubygems included with rh-ruby25, rh-ruby25-rubygems-2.7.6-6.el7.noarch, seems incompatible. Updating bundler with rubygems seems to fix the issue. :man_shrugging: 