### PR TITLE
clean yum after installing the client repository

### DIFF
--- a/roles/foreman_client_repositories/tasks/repo.yml
+++ b/roles/foreman_client_repositories/tasks/repo.yml
@@ -13,3 +13,11 @@
     name: https://yum.theforeman.org/client/{{ foreman_client_repositories_version }}/{{ foreman_client_repositories_dists[ansible_os_family] }}{{ ansible_distribution_major_version }}/x86_64/foreman-client-release.rpm
     state: present
   when: foreman_client_repositories_environment == "release"
+
+- name: 'Clean yum'
+  command: 'yum clean all'
+  args:
+    warn: false
+  tags:
+    - packages
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
now that the client packages are signed, we need to ensure we're getting
the right RPM in an upgrade scenario.

longer explanation:
during our katello upgrade tests, we install a base version of katello
and then uprade it twice until we reach a certain version. so for
example when installing 1.20/3.10 we deploy a repo called
"foreman-client" pointing at the 1.20 client bits. then we upgrade to
1.21/3.11, we update the foreman-client repo to point at 1.21, but due
to the fact that we used yum before, it still has a cached version of
the 1.20 metadata on disk. now, when we try to use the 1.21 client repo,
it uses the 1.20 metadata and either does not find the packages OR finds
them with a wrong/different signature and the checksums don't match.