### PR TITLE
Only assign proxy to default taxonomies in 1.21 and 1.22

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -67,6 +67,10 @@ fi
 }
 
 @test "Assign proxy and environment to default taxonomies" {
+  # Foreman 1.20 and earlier didn't test with taxonomies on
+  # Foreman 1.23 is expected to have a fix for this via https://projects.theforeman.org/issues/26092
+  FOREMAN_VERSION=$(tForemanVersion)
+  [[ $FOREMAN_VERSION != '1.21' ]] && [[ $FOREMAN_VERSION != '1.22' ]] && skip "Assignment not needed"
   hammer proxy update --name=$(hostname -f) --locations "Default Location" --organizations "Default Organization"
   hammer environment update --name=production --locations "Default Location" --organizations "Default Organization"
 }


### PR DESCRIPTION
Foreman 1.20 and earlier didn't test with taxonomies on. Foreman 1.23 is expected to have a fix for this via https://projects.theforeman.org/issues/26092.