### PR TITLE
Correct upgrade box names

### DIFF
--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -1,3 +1,4 @@
 forklift_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_server_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_proxy_name: "pipeline-upgrade-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_boxes: "{{ {forklift_server_name: server_box} }}"


### PR DESCRIPTION
45ada03a29a67d1458e814022dfe9e3eec46a3ec unified the box naming, but failed to define the proxy pipeline for upgrades. It also includes the -server and -proxy to be consistent with install pipelines.