### PR TITLE
Delete host right before registration

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -25,10 +25,6 @@ setup() {
   hammer organization create --name="${ORGANIZATION}" | grep -q "Organization created"
 }
 
-@test "delete host if present" {
-  hammer host delete --name="`hostname`" || echo "Could not delete host"
-}
-
 @test "create a product" {
   hammer product create --organization="${ORGANIZATION}" --name="${PRODUCT}" | grep -q "Product created"
 }
@@ -123,6 +119,10 @@ enabled=1
 EOF
   fi
   tPackageExists subscription-manager || tPackageInstall subscription-manager
+}
+
+@test "delete host if present" {
+  hammer host delete --name="`hostname`" || echo "Could not delete host"
 }
 
 @test "register subscription manager with username and password" {


### PR DESCRIPTION
this should fix a luna issue where the host is
recreated by a puppet checkin between the time
that it is deleted and registration occurs