### PR TITLE
Always assign env to taxonomies in puppet bats

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -66,13 +66,16 @@ fi
   [ $count -gt 1 ]
 }
 
-@test "Assign proxy and environment to default taxonomies" {
+@test "Assign environment to default taxonomies" {
+  hammer environment update --name=production --locations "Default Location" --organizations "Default Organization"
+}
+
+@test "Assign proxy to default taxonomies" {
   # Foreman 1.20 and earlier didn't test with taxonomies on
   # Foreman 1.23 is expected to have a fix for this via https://projects.theforeman.org/issues/26092
   FOREMAN_VERSION=$(tForemanVersion)
   [[ $FOREMAN_VERSION != '1.21' ]] && [[ $FOREMAN_VERSION != '1.22' ]] && skip "Assignment not needed"
   hammer proxy update --name=$(hostname -f) --locations "Default Location" --organizations "Default Organization"
-  hammer environment update --name=production --locations "Default Location" --organizations "Default Organization"
 }
 
 @test "assign puppet class to host" {


### PR DESCRIPTION
Katello upgrade tests fail because the production environment doesn't
match the host taxonomies.