### PR TITLE
Use --no-colors in foreman installer

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -8,6 +8,7 @@ foreman_installer_scenario_flag: '{{ "--scenario" if foreman_installer_scenario 
 foreman_installer_upgrade: False
 foreman_installer_command: foreman-installer
 foreman_installer_custom_hiera: ""
+foreman_installer_no_colors: True
 
 # Comma-separated list of "organization/module/pr_number", e.g. "katello/foreman_proxy_content/37,katello/certs/34"
 foreman_installer_module_prs: []

--- a/roles/foreman_installer/tasks/install.yml
+++ b/roles/foreman_installer/tasks/install.yml
@@ -31,6 +31,7 @@
 - name: 'Run installer'
   shell: >
       {{ foreman_installer_command }} {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
+      {{ (foreman_installer_no_colors == True) | ternary("--no-colors", "") }}
       {{ foreman_installer_scenario_flag }} {{ foreman_installer_scenario }}
       {{ foreman_installer_options_joined }}
   when: not foreman_installer_skip_installer


### PR DESCRIPTION
Ansible's colors conflict with Foreman's. It's really obvious in the Jenkins output.

![image](https://user-images.githubusercontent.com/761923/61663914-ac2e3e00-ac9f-11e9-81da-01620c880bae.png)