### PR TITLE
Revert "Install virt-who via the installer"

### DIFF
--- a/pipelines/vars/luna_base.yml
+++ b/pipelines/vars/luna_base.yml
@@ -11,7 +11,6 @@ foreman_installer_options_internal_use_only:
   - "--enable-foreman-cli-remote-execution"
   - "--enable-foreman-cli-tasks"
   - "--enable-foreman-cli-templates"
-  - "--enable-foreman-cli-virt-who-configure"
   - "--enable-foreman-plugin-ansible"
   - "--enable-foreman-plugin-bootdisk"
   - "--enable-foreman-plugin-discovery"
@@ -19,13 +18,14 @@ foreman_installer_options_internal_use_only:
   - "--enable-foreman-plugin-openscap"
   - "--enable-foreman-plugin-remote-execution"
   - "--enable-foreman-plugin-templates"
-  - "--enable-foreman-plugin-virt-who-configure"
   - "--enable-foreman-proxy-plugin-ansible"
   - "--enable-foreman-proxy-plugin-discovery"
   - "--enable-foreman-proxy-plugin-openscap"
   - "--enable-foreman-proxy-plugin-remote-execution-ssh"
 foreman_installer_additional_packages:
   - katello
+  - tfm-rubygem-foreman_virt_who_configure
+  - tfm-rubygem-hammer_cli_foreman_virt_who_configure
 server_box:
   box: "{{ pipeline_os }}"
   memory: 8192

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -9,7 +9,6 @@
       - "--enable-foreman-cli-remote-execution"
       - "--enable-foreman-cli-tasks"
       - "--enable-foreman-cli-templates"
-      - "--enable-foreman-cli-virt-who-configure"
       - "--enable-foreman-plugin-ansible"
       - "--enable-foreman-plugin-bootdisk"
       - "--enable-foreman-plugin-discovery"
@@ -17,11 +16,13 @@
       - "--enable-foreman-plugin-openscap"
       - "--enable-foreman-plugin-remote-execution"
       - "--enable-foreman-plugin-templates"
-      - "--enable-foreman-plugin-virt-who-configure"
       - "--enable-foreman-proxy-plugin-ansible"
       - "--enable-foreman-proxy-plugin-discovery"
       - "--enable-foreman-proxy-plugin-openscap"
       - "--enable-foreman-proxy-plugin-remote-execution-ssh"
       - "--katello-enable-ostree true"
+    foreman_installer_additional_packages:
+      - tfm-rubygem-foreman_virt_who_configure
+      - tfm-rubygem-hammer_cli_foreman_virt_who_configure
   roles:
     - role: katello

--- a/roles/luna_provisioning/defaults/main.yml
+++ b/roles/luna_provisioning/defaults/main.yml
@@ -5,14 +5,15 @@ luna_provisioning_installer_internal_options:
   - "--enable-foreman-cli-remote-execution"
   - "--enable-foreman-cli-tasks"
   - "--enable-foreman-cli-templates"
-  - "--enable-foreman-cli-virt-who-configure"
   - "--enable-foreman-plugin-ansible"
   - "--enable-foreman-plugin-bootdisk"
   - "--enable-foreman-plugin-discovery"
   - "--enable-foreman-plugin-hooks"
   - "--enable-foreman-plugin-remote-execution"
   - "--enable-foreman-plugin-templates"
-  - "--enable-foreman-plugin-virt-who-configure"
   - "--enable-foreman-proxy-plugin-ansible"
   - "--enable-foreman-proxy-plugin-discovery"
   - "--enable-foreman-proxy-plugin-remote-execution-ssh"
+luna_provisioning_additional_packages:
+  - tfm-rubygem-foreman_virt_who_configure
+  - tfm-rubygem-hammer_cli_foreman_virt_who_configure

--- a/roles/luna_provisioning/meta/main.yml
+++ b/roles/luna_provisioning/meta/main.yml
@@ -5,6 +5,7 @@ dependencies:
     libvirt_tftp: true
   - role: katello_provisioning
     katello_provisioning_installer_options: "{{ luna_provisioning_installer_options }} + {{ luna_provisioning_installer_internal_options }}"
+    foreman_installer_additional_packages: "{{ luna_provisioning_additional_packages }}"
   - role: 'plugins/foreman_ansible/seed'
   # use role instead of installer options for openscap to install theforeman-foreman_scap_client puppet module
   - role: 'plugins/foreman_openscap/install'


### PR DESCRIPTION
This reverts commit c270c58125cb75868272b2001e017ddc65dd34c4 which is needed because the luna pipeline in upgrades fails because 1.22 doesn't have this option yet. https://github.com/theforeman/foreman-installer/pull/380 is open for that.