### PR TITLE
use unsafe writes for forklift boxes

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -14,6 +14,9 @@
   vars:
     forklift_url: "https://github.com/theforeman/forklift"
     forklift_version: master
+    forklift_config:
+      libvirt_options:
+        volume_cache: unsafe
   tasks:
     - name: 'Install Forklift dependencies'
       package:
@@ -28,3 +31,8 @@
         repo: "{{ forklift_url }}"
         version: "{{ forklift_version }}"
         dest: './forklift'
+
+    - name: 'Configure Forklift'
+      copy:
+        content: "{{ forklift_config | to_nice_yaml }}"
+        dest: './forklift/vagrant/settings.yaml'


### PR DESCRIPTION
this has a ~2× speedup in my tests (from ~60 to ~30 minutes) and should
be fine as those are throw-away VMs anyways