### PR TITLE
Disable the CentOS CR repository

### DIFF
--- a/roles/epel_repositories/tasks/main.yml
+++ b/roles/epel_repositories/tasks/main.yml
@@ -20,7 +20,7 @@
     path: /etc/yum.repos.d/CentOS-CR.repo
     section: cr
     option: enabled
-    value: 1
+    value: 0
     no_extra_spaces: True
   tags:
     - packages


### PR DESCRIPTION
This contains a broken subscription-manager that's part of RHEL 7.7. Since CentOS 7.7 isn't released yet, we can workaround this but once it is released, we'll be hit by it again.