### PR TITLE
Load helpers in fb-test-katello

### DIFF
--- a/bats/fb-test-katello.bats
+++ b/bats/fb-test-katello.bats
@@ -3,6 +3,9 @@
 
 set -o pipefail
 
+load os_helper
+load foreman_helper
+
 @test "check hammer ping" {
   FOREMAN_VERSION=$(tForemanVersion)
   if [ $FOREMAN_VERSION == '1.24' ]; then


### PR DESCRIPTION
In b09e85d9153c1da132f8420f7f9efba1a04208e6 a version check was added but the helpers weren't loaded.