### PR TITLE
update method for querying foreman server

### DIFF
--- a/roles/foreman_proxy_content/tasks/devel_install.yml
+++ b/roles/foreman_proxy_content/tasks/devel_install.yml
@@ -1,12 +1,8 @@
 ---
-- name: 'Get Server Hostname'
-  shell: hostname -f
-  delegate_to: "{{ foreman_proxy_content_server }}"
-  register: server_fqdn
-
 - name: 'Query Foreman server'
   uri:
-    url: "{{ 'https://' ~ server_fqdn.stdout }}"
+    url: http://localhost:3000/api/v2/ping
+  delegate_to: "{{ foreman_proxy_content_server }}"
   ignore_errors: True
   register: foreman_get
 


### PR DESCRIPTION
This is a follow-up PR to #1017.  Querying `localhost` directly on the Foreman server is a simpler method to see if the Foreman server is running.