### PR TITLE
Drop Katello 3.8 and 3.9

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -1,26 +1,4 @@
 installers:
-  - foreman: '1.19'
-    katello: '3.8'
-    pulp: '2.16'
-    puppet: 5
-    boxes:
-      - 'centos7'
-      - 'centos7-fips'
-      - 'debian9'
-      - 'ubuntu1604'
-      - 'ubuntu1804'
-
-  - foreman: '1.20'
-    katello: '3.9'
-    pulp: '2.17'
-    puppet: 5
-    boxes:
-      - 'centos7'
-      - 'centos7-fips'
-      - 'debian9'
-      - 'ubuntu1604'
-      - 'ubuntu1804'
-
   - foreman: '1.20'
     katello: '3.10'
     pulp: '2.18'


### PR DESCRIPTION
These are no longer supported and shouldn't be shown anymore. Previously we included these to test upgrades but due to a candlepin issue a fresh installation is no longer possible without workarounds. On the Foreman side the 3.10 release pipeline will drop upgrade testing. Note that 3.10 is out of support anyway, but it's still needed to push in critical upgrade fixes.