### PR TITLE
Move foreman-initial-admin-password to install.yaml

### DIFF
--- a/pipelines/pipeline_katello_lbproxy.yml
+++ b/pipelines/pipeline_katello_lbproxy.yml
@@ -57,7 +57,6 @@
     foreman_installer_scenario: katello
     foreman_installer_disable_system_checks: true
     foreman_installer_options_internal_use_only:
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--enable-foreman-plugin-remote-execution"
       - "--enable-foreman-proxy-plugin-remote-execution-ssh"
     foreman_installer_additional_packages:

--- a/pipelines/upgrade_pipeline.yml
+++ b/pipelines/upgrade_pipeline.yml
@@ -95,6 +95,7 @@
     - vars/{{ pipeline_type }}_server.yml
   vars:
     foreman_installer_upgrade: True
+    foreman_installer_options_internal_use_only: []
   roles:
     - role: forklift_versions
       scenario: "{{ pipeline_type }}"
@@ -119,6 +120,7 @@
     - vars/{{ pipeline_type }}_proxy.yml
   vars:
     foreman_installer_upgrade: True
+    foreman_installer_options_internal_use_only: []
     foreman_proxy_content_upgrade: True
     foreman_proxy_content_server: "{{ forklift_server_name }}"
   roles:
@@ -141,6 +143,7 @@
   become: yes
   vars:
     foreman_installer_upgrade: True
+    foreman_installer_options_internal_use_only: []
   vars_files:
     - vars/upgrade_base.yml
     - vars/{{ pipeline_type }}_base.yml
@@ -164,6 +167,7 @@
   become: yes
   vars:
     foreman_installer_upgrade: True
+    foreman_installer_options_internal_use_only: []
     foreman_proxy_content_upgrade: True
     foreman_proxy_content_server: "{{ forklift_server_name }}"
   vars_files:

--- a/pipelines/upgrade_pipeline.yml
+++ b/pipelines/upgrade_pipeline.yml
@@ -93,9 +93,6 @@
     - vars/{{ pipeline_type }}_base.yml
     - vars/{{ pipeline_type }}_base_release.yml
     - vars/{{ pipeline_type }}_server.yml
-  vars:
-    foreman_installer_upgrade: True
-    foreman_installer_options_internal_use_only: []
   roles:
     - role: forklift_versions
       scenario: "{{ pipeline_type }}"
@@ -107,6 +104,8 @@
     - foreman_server_repositories
     - foreman_client_repositories
     - role: foreman_installer
+      foreman_installer_upgrade: True
+      foreman_installer_options_internal_use_only: []
       foreman_installer_skip_installer: "{{ true if forklift_upgrade_version_start == forklift_upgrade_version_intermediate else false }}"
 
 - name: upgrade proxy to intermediate version
@@ -119,10 +118,9 @@
     - vars/{{ pipeline_type }}_base_release.yml
     - vars/{{ pipeline_type }}_proxy.yml
   vars:
-    foreman_installer_upgrade: True
-    foreman_installer_options_internal_use_only: []
     foreman_proxy_content_upgrade: True
     foreman_proxy_content_server: "{{ forklift_server_name }}"
+    foreman_installer_skip_installer: "{{ true if forklift_upgrade_version_start == forklift_upgrade_version_intermediate else false }}"
   roles:
     - role: forklift_versions
       scenario: "{{ pipeline_type }}"
@@ -134,16 +132,11 @@
     - foreman_server_repositories
     - foreman_client_repositories
     - foreman_proxy_content
-    - role: foreman_installer
-      foreman_installer_skip_installer: "{{ true if forklift_upgrade_version_start == forklift_upgrade_version_intermediate else false }}"
 
 - name: upgrade server to final version
   hosts:
     - "{{ forklift_server_name }}"
   become: yes
-  vars:
-    foreman_installer_upgrade: True
-    foreman_installer_options_internal_use_only: []
   vars_files:
     - vars/upgrade_base.yml
     - vars/{{ pipeline_type }}_base.yml
@@ -159,15 +152,15 @@
       scenario_version: "{{ forklift_upgrade_version_final }}"
     - foreman_server_repositories
     - foreman_client_repositories
-    - foreman_installer
+    - role: foreman_installer
+      foreman_installer_upgrade: True
+      foreman_installer_options_internal_use_only: []
 
 - name: upgrade proxy to final version
   hosts:
     - "{{ forklift_proxy_name }}"
   become: yes
   vars:
-    foreman_installer_upgrade: True
-    foreman_installer_options_internal_use_only: []
     foreman_proxy_content_upgrade: True
     foreman_proxy_content_server: "{{ forklift_server_name }}"
   vars_files:
@@ -186,7 +179,6 @@
     - foreman_server_repositories
     - foreman_client_repositories
     - foreman_proxy_content
-    - foreman_installer
 
 - name: run tests
   hosts:

--- a/pipelines/vars/foreman_base.yml
+++ b/pipelines/vars/foreman_base.yml
@@ -1,6 +1,5 @@
 foreman_installer_scenario: foreman
 foreman_installer_options_internal_use_only:
-  - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
   - "--puppet-server-max-active-instances 1"
   - "--puppet-server-jvm-min-heap-size 1G"
   - "--puppet-server-jvm-max-heap-size 1G"

--- a/pipelines/vars/katello_server.yml
+++ b/pipelines/vars/katello_server.yml
@@ -2,7 +2,6 @@ foreman_installer_scenario: katello
 foreman_installer_additional_packages:
   - katello
 foreman_installer_options_internal_use_only:
-  - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
   - "--puppet-server-max-active-instances 1"
   - "--puppet-server-jvm-min-heap-size 1G"
   - "--puppet-server-jvm-max-heap-size 1G"

--- a/pipelines/vars/luna_base.yml
+++ b/pipelines/vars/luna_base.yml
@@ -2,7 +2,6 @@ foreman_server_repositories_katello: true
 foreman_installer_scenario: katello
 foreman_installer_disable_system_checks: true
 foreman_installer_options_internal_use_only:
-  - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
   - "--puppet-server-max-active-instances 1"
   - "--puppet-server-jvm-min-heap-size 1G"
   - "--puppet-server-jvm-max-heap-size 1G"

--- a/playbooks/bats_pipeline_foreman_nightly.yml
+++ b/playbooks/bats_pipeline_foreman_nightly.yml
@@ -2,7 +2,6 @@
   become: true
   vars:
     foreman_installer_options_internal_use_only:
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"
       - "--puppet-server-jvm-max-heap-size 1G"

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -11,7 +11,6 @@
       - katello
     foreman_installer_disable_system_checks: true
     foreman_installer_options_internal_use_only:
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--katello-enable-ostree=true"
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"

--- a/playbooks/foreman_platform.yml
+++ b/playbooks/foreman_platform.yml
@@ -3,7 +3,6 @@
   roles:
     - role: katello
       foreman_installer_options_internal_use_only:
-          - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
           - "--enable-foreman-plugin-discovery"
           - "--enable-foreman-plugin-bootdisk"
           - "--enable-foreman-plugin-remote-execution"

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -3,7 +3,6 @@
   become: true
   vars:
     foreman_installer_options:
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--enable-foreman-cli-discovery"
       - "--enable-foreman-cli-openscap"
       - "--enable-foreman-cli-remote-execution"

--- a/playbooks/luna_demo_environment.yml
+++ b/playbooks/luna_demo_environment.yml
@@ -36,7 +36,6 @@
       - rubygem-ruby-libvirt
       - katello
     foreman_installer_options:
-      - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--foreman-initial-organization {{ katello_provisioning_organization }}"
       - "--foreman-initial-location {{ katello_provisioning_location }}"
       - "--puppet-show-diff=true"

--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -24,5 +24,4 @@ foreman_installer_module_branches: []
 # so we put it in internal_use_only in a role or playbook.
 # The foreman_installer_options is intended for the end user to override.
 foreman_installer_options: []
-foreman_installer_options_internal_use_only:
-  - '{{ "--foreman-initial-admin-password" if foreman_installer_scenario != "foreman-proxy-content" else "" }} {{ foreman_installer_admin_password if foreman_installer_scenario != "foreman-proxy-content" else "" }}'
+foreman_installer_options_internal_use_only: []

--- a/roles/foreman_installer/tasks/install.yml
+++ b/roles/foreman_installer/tasks/install.yml
@@ -12,6 +12,19 @@
 - debug:
     msg: "Foreman installer version {{ foreman_installer_version_file['content'] | b64decode }}"
 
+- name: 'Clear initial admin password option'
+  set_fact:
+    foreman_installer_admin_password_option: ""
+
+- name: 'Set initial admin password option'
+  set_fact:
+    foreman_installer_admin_password_option: "--foreman-initial-admin-password '{{ foreman_installer_admin_password }}'"
+  when:
+    - foreman_installer_scenario != "foreman-proxy-content"
+    - foreman_installer_scenario != "katello-devel"
+    - not foreman_installer_upgrade|bool
+    - ('--foreman-initial-admin-password' not in foreman_installer_options_internal_use_only)
+
 - name: 'Join options'
   set_fact:
     foreman_installer_options_joined: "{{ foreman_installer_options | join(' ') }} {{ foreman_installer_options_internal_use_only | join(' ') }}"
@@ -34,6 +47,7 @@
       {{ (foreman_installer_no_colors|bool) | ternary("--no-colors", "") }}
       {{ (foreman_installer_disable_system_checks|bool) | ternary("--disable-system-checks", "") }}
       {{ foreman_installer_scenario_flag }} {{ foreman_installer_scenario }}
+      {{ foreman_installer_admin_password_option }}
       {{ foreman_installer_options_joined }}
   when: not foreman_installer_skip_installer
   tags:

--- a/roles/foreman_proxy_content/tasks/upgrade.yml
+++ b/roles/foreman_proxy_content/tasks/upgrade.yml
@@ -4,13 +4,10 @@
 - name: 'Run installer upgrade'
   include_role:
     name: foreman_installer
-    tasks_from: install
   vars:
     foreman_installer_scenario: foreman-proxy-content
-    foreman_installer_disable_system_checks: True
+    foreman_installer_upgrade: True
     foreman_installer_options_internal_use_only:
-      - --upgrade
-      - --certs-update-all
       - --certs-regenerate=true
       - --certs-deploy=true
       - --certs-tar-file="{{ foreman_proxy_content_certs_tar }}"


### PR DESCRIPTION
Rather than keeping it as a default value, this moves it to install.yaml which has more information about whether it really needs to be there.  Besides scenarios that are not foreman-proxy-content (which doesn't include the foreman class), it also doesn't make sense on upgrades since it's the initial password.

A nice benefit is that it isn't spread over the various playbooks anymore.