### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
-sudo: false
 language: python
 python:
   - 2.7
-install:
-  - |
-    if git diff origin/master --name-only | grep -q "vagrant"; then
-      rvm install 2.2.4
-    fi
-
-  - |
-    if git diff origin/master --name-only | grep -q "playbooks\|roles\|containers/roles"; then
-      pip install ansible-lint
-    fi
+dist: bionic
+addons:
+  apt:
+    packages:
+      - ansible-lint
+      - ruby-bundler
 script:
   - |
     if git diff origin/master --name-only | grep -q "vagrant"; then

--- a/vagrant/.rubocop.yml
+++ b/vagrant/.rubocop.yml
@@ -23,14 +23,8 @@ MethodLength:
 HashSyntax:
   Enabled: false # don't force 1.9 hash syntax
 
-Metrics/AbcSize:
-  Max: 20
-
 Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
-
-Metrics/AbcSize:
-  Max: 20
 
 Metrics/AbcSize:
   Max: 60

--- a/vagrant/Rakefile
+++ b/vagrant/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|

--- a/vagrant/lib/forklift.rb
+++ b/vagrant/lib/forklift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.dirname(__FILE__)
 
 files = Dir[File.dirname(__FILE__) + '/forklift/**/*.rb']

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -20,7 +20,7 @@ module Forklift
 
     def settings
       overrides = {}
-      settings_file = "#{File.dirname(__FILE__)}/../../settings.yaml"
+      settings_file = File.join(__dir__, '..', '..', 'settings.yaml')
       default_settings = {
         'memory' => 6144,
         'cpus' => 2,

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -72,11 +72,10 @@ module Forklift
 
         machine.vm.box_url = box.fetch('box_url') if box.key?('box_url')
 
-        domain = create_domain(box)
-
         machine.vm.hostname = if box.fetch('hostname', false)
                                 box.fetch('hostname')
                               else
+                                domain = create_domain(box)
                                 "#{box.fetch('name').to_s.tr('.', '-')}.#{domain}"
                               end
 

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Forklift
   class BoxDistributor
 
-    VAGRANTFILE_API_VERSION = '2'.freeze
+    VAGRANTFILE_API_VERSION = '2'
 
     if Gem.loaded_specs['vagrant']
       SUPPORT_NAMED_PROVISIONERS = Gem.loaded_specs['vagrant'].version >= Gem::Version.create('1.7')

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'erb'
 require 'yaml'

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -22,7 +22,7 @@ module Forklift
     private
 
     def default_root_dir
-      "#{File.dirname(__FILE__)}/../../"
+      File.join(__dir__, '..', '..')
     end
 
     def default_locations

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Forklift
   class BoxLoader
 

--- a/vagrant/lib/forklift/compat.rb
+++ b/vagrant/lib/forklift/compat.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Gem.loaded_specs['vagrant']
   require 'vagrant/util/deep_merge'
 else

--- a/vagrant/test/lib/box_loader_test.rb
+++ b/vagrant/test/lib/box_loader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestBoxLoader < Minitest::Test

--- a/vagrant/test/test_helper.rb
+++ b/vagrant/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'forklift'

--- a/vagrant/test/test_helper.rb
+++ b/vagrant/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'mocha/mini_test'
 


### PR DESCRIPTION
This now uses a bionic image which has a package for ansible-lint. The base image also stopped shipping ruby and bundler so we explicitly install it.

It also adds two commits with changes to vagrant to ensure the Ruby tests are triggered. These changes by themselves are also useful.