### PR TITLE
Fixes stable Katello box name

### DIFF
--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -76,5 +76,5 @@ centos7-dynflow-devel:
       dynflow_devel_github_fork_remote_name: 'origin'
 
 centos7-katello-devel-stable:
-  box_name: centos7-katello-devel-stable
+  box_name: katello/katello-devel
   hostname: centos7-katello-devel-stable.example.com


### PR DESCRIPTION
This should have been pointing to https://app.vagrantup.com/katello/boxes/katello-devel 