### PR TITLE
Allow having unsupported versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@
 ENV['LANG'] = 'en_US.UTF-8'
 ENV['LC_ALL'] = 'en_US.UTF-8'
 VAGRANTFILE_DIR = File.dirname(__FILE__)
+ONLY_SUPPORTED = !ENV.key?('FORKLIFT_SHOW_UNSUPPORTED')
 
 require "#{VAGRANTFILE_DIR}/vagrant/lib/forklift"
 
@@ -36,7 +37,7 @@ end
 
 migrate_boxes!
 migrate_settings!
-loader = Forklift::BoxLoader.new("#{VAGRANTFILE_DIR}/vagrant")
+loader = Forklift::BoxLoader.new(File.join(VAGRANTFILE_DIR, 'vagrant'), nil, ONLY_SUPPORTED)
 loader.load!
 distributor = Forklift::BoxDistributor.new(loader.boxes)
 distributor.distribute!

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -3,6 +3,7 @@ installers:
     katello: '3.10'
     pulp: '2.18'
     puppet: 5
+    supported: false
     boxes:
       - 'centos7'
       - 'centos7-fips'
@@ -14,6 +15,7 @@ installers:
     katello: '3.11'
     pulp: '2.18'
     puppet: 5
+    supported: false
     boxes:
       - 'centos7'
       - 'centos7-fips'

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -11,9 +11,10 @@ module Forklift
 
     attr_accessor :boxes
 
-    def initialize(versions)
+    def initialize(versions, only_supported = true)
       @versions = versions
       @boxes = {}
+      @only_supported = only_supported
     end
 
     def add_boxes!(box_file)
@@ -50,6 +51,8 @@ module Forklift
 
     def process_versions(config)
       @versions['installers'].each do |version|
+        next if @only_supported && version['supported'] == false
+
         version['boxes'].each do |base_box|
           next unless config['boxes'].key?(base_box)
 

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -5,10 +5,10 @@ module Forklift
 
     attr_accessor :locations
 
-    def initialize(root_dir = nil, locations = nil)
+    def initialize(root_dir = nil, locations = nil, only_supported = true)
       @root_dir = root_dir || default_root_dir
       @locations = locations || default_locations
-      @box_factory = BoxFactory.new(versions)
+      @box_factory = BoxFactory.new(versions, only_supported)
     end
 
     def load!


### PR DESCRIPTION
We always have older versions because they're needed in upgrade scenarios. However, that uses a different mechanism than Vagrantfile. This allows trimming down the list of default boxes while still allowing upgrades.

It also updates the Fedora versions to current ones