### PR TITLE
Drop docker testing instructions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -229,38 +229,6 @@ ansible:
       - myfork/foreman/add-puma
 ```
 
-## Jenkins Job Builder Development
-
-When modifying or creating new Jenkins jobs, it's helpful to generate the XML file to compare to the one Jenkins has. In order to do this, you need a properly configured Jenkins Job Builder environment. The dockerfile under docker/jjb can be used as a properly configured environment. To begin, copy `docker-compose.yml.example` to `docker-compose.yml`:
-
-```
-cd docker/jjb
-cp docker-compose.yml.example docker-compose.yml
-```
-
-Now edit the docker-compose configuration file to point at your local copy of the `foreman-infra` repository so that it will mount and record changes locally when working within the container. Ensure that either your docker has permissions to the repository being mounted or that the appropriate Docker SELinux context is set: [Docker SELinux with Volumes](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/). Now we are ready to do any Jenkins Job Builder work. For example, if you wanted to generate all the XML files for all jobs:
-
-```
-docker-compose run jjb bash
-cd foreman-infra/puppet/modules/jenkins_job_builder/files/theforeman.org
-jenkins-jobs -l debug test -r . -o /tmp/jobs
-```
-
-## Redmine Development
-
-The Foreman project uses Redmine to handle issue management via forked instance of Redmine that runs on Openshift. Testing upgrades, making plugins or patches is sometimes desired to achieve functionality which we need. The dockerfile under docker/redmine can be used as a properly configured Redmine environment for development. To begin, copy `docker-compose.yml.example` to `docker-compose.yml`:
-
-```
-cd docker/redmine
-cp docker-compose.yml.example docker-compose.yml
-```
-
-Assuming you have a clone of the Redmine repository somewhere locally, edit the `docker-compose.yml` configuration file to point at your local copy of the `redmine` repository so that it will mount and record changes locally when working within the container. Ensure that either your docker has permissions to the repository being mounted or that the appropriate Docker SELinux context is set: [Docker SELinux with Volumes](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/). Now we are ready to start up Redmine and make changes:
-
-```
-docker-compose up redmine
-```
-
 ## Hammer Development
 
 Hammer is the command line interface (CLI) to Foreman and Katello. It supports plugins

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,6 @@
 This section covers test infrastructure and environments that can be spun up using Forklift.
 
  * [Bats Testing](#bats-testing)
- * [Client Testing with Docker](#client-testing-with-docker)
  * [Running Robottelo Tests](#running-robottelo-tests)
 
 ## Bats Testing
@@ -97,42 +96,6 @@ foreman_client_repositories_version: "{{ foreman_repositories_version }}"
 katello_version_start: '3.9'
 katello_version_intermediate: '3.10'
 katello_version_final: '{{ katello_version }}'
-```
-
-## Client Testing With Docker
-
-The docker/clients directory contains setup and configuration to register clients via subscription-manager using an activation key and start katello-agent. Before using the client containers, Docker and docker-compose need to be installed and setup. On a Fedora based system (Fedora 23 or greater):
-
-```
-sudo yum install docker docker-compose
-sudo service docker start
-sudo chkconfig docker on
-sudo usermod -aG docker your_username
-```
-
-For other platforms see the official instructions at:
-
- * [docker](https://docs.docker.com/installation/)
- * [docker-compose](https://docs.docker.com/compose/install/)
-
-In order to use the client containers you will also need the following:
-
- * Foreman/Katello server IP address
- * Foreman/Katello server hostname
- * Foreman Organization
- * Activation Key
- * Katello version you have deployed (e.g. nightly, 2.2)
-
-Begin by changing into the docker/clients directory and copying the `docker-compose.yml.example` file to `docker-compose.yml` and filling in the necessary information gathered above. At this point, you can now spin-up one or more clients of varying types. For example, if you wanted to spin up a centos6 based client:
-
-```
-docker-compose up el6
-```
-
-If you want to spin up more than one client, let's say 10 for this example, the docker-compose scale command can be used:
-
-```
-docker-compose scale el6=10
 ```
 
 ## Running Robottelo Tests


### PR DESCRIPTION
20ec03e80739626ec68afd1959d80da60f8b64a3 removed the docker-compose configs, so these instructions no longer work.