### PR TITLE
Updating stable dev box default memory

### DIFF
--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -77,4 +77,5 @@ centos7-dynflow-devel:
 
 centos7-katello-devel-stable:
   box_name: katello/katello-devel
+  memory: 9000
   hostname: centos7-katello-devel-stable.example.com


### PR DESCRIPTION
This will go with 512MB if no default is specified