### PR TITLE
Specify remote_tmp in ansible config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,4 @@ retry_files_save_path = $HOME/.ansible/retry-files
 remote_user = vagrant
 host_key_checking = False
 force_color = 1
+remote_tmp = /tmp/ansible


### PR DESCRIPTION
This prevents directories like `~jomitsch` being created when boxes are created with packer.