### PR TITLE
Fix sudo requirement for local_action task in customize_home role

### DIFF
--- a/roles/customize_home/tasks/main.yml
+++ b/roles/customize_home/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Check for specified files to copy to home directory
+  become: false
   local_action:
     module: stat
     path: "{{ playbook_dir | dirname }}/user_devel_env_files/"


### PR DESCRIPTION
This doesn't work under a non root user. local_action will try to sudo by default but no password specified.

```
$ ansible --version
ansible 2.9.2
  config file = None
  configured module search path = ['/Users/amasolov/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.9.2/libexec/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.5 (default, Nov  1 2019, 02:16:23) [Clang 11.0.0 (clang-1100.0.33.8)]

...
TASK [customize_home : Check for specified files to copy to home directory] ****
fatal: [centos7-katello-devel -> localhost]: FAILED! => changed=false
  module_stderr: |-
    sudo: a password is required
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
...
```
