### PR TITLE
Don't escalate priveleges for dev box local file strategy

### DIFF
--- a/roles/customize_home/tasks/main.yml
+++ b/roles/customize_home/tasks/main.yml
@@ -2,6 +2,7 @@
   local_action:
     module: stat
     path: "{{ playbook_dir | dirname }}/user_devel_env_files/"
+  become: no
   register: custom_home
 
 - name: Copy files to home directory


### PR DESCRIPTION
For users without a ` NOPASSWD: ALL` entry for their user in `/etc/sudoers`, ansible will fail on the step checking permissions of the local machine for the local directory devel environment setup. This means that the user will be prompted for the sudo password on this step and ansible will fail.

For some reason, this happens on `centos7-katello-devel`, but not `centos7-katello-devel-stable`, even though the role is run on both boxes. I'm not sure the delta there, but would like to figure it out at some point. Theoretically, since it is a local action, the VM shouldn't affect it.

To recreate, you can comment out the `NOPASSWD: ALL` line in your `/etc/sudoers` with `sudo visudo` and spin up a `centos7-katello-devel` box. You don't need to have the local devel env files folder to recreate the error. On master, you should be able to recreate the error. The `become: no` fix in this branch prevents ansible from escalating permissions, so it will no longer fail with this branch.