### PR TITLE
Allow smoker to fail

### DIFF
--- a/roles/pytest_project/defaults/main.yml
+++ b/roles/pytest_project/defaults/main.yml
@@ -18,3 +18,4 @@ pytest_project_version: master
 pytest_project_junit_output: junit.xml
 pytest_project_markers:
 pytest_project_command_args:
+pytest_project_ignore_errors: no

--- a/roles/pytest_project/tasks/run.yml
+++ b/roles/pytest_project/tasks/run.yml
@@ -10,5 +10,6 @@
 
 - name: 'Run tests'
   command: "{{ pytest_project_command }}"
+  ignore_errors: "{{ pytest_project_ignore_errors }}"
   args:
     chdir: "{{ pytest_project_directory }}"

--- a/roles/smoker/tasks/main.yml
+++ b/roles/smoker/tasks/main.yml
@@ -30,3 +30,4 @@
     pytest_project_directory: "{{ smoker_directory }}"
     pytest_project_markers: "{{ smoker_markers }}"
     pytest_project_command_args: "{{ smoker_command_args }}"
+    pytest_project_ignore_errors: yes


### PR DESCRIPTION
Currently smoker is being integrated. Some parts can't be tested locally so it's important to allow the pipelines to continue.