### PR TITLE
Store smoker junit in /tmp

### DIFF
--- a/pipelines/install_pipeline.yml
+++ b/pipelines/install_pipeline.yml
@@ -97,6 +97,7 @@
     - vars/install_base.yml
     - vars/{{ pipeline_type }}_base.yml
   vars:
+    pytest_project_junit_output: /tmp/smoker-junit.xml
     smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"

--- a/pipelines/upgrade_pipeline.yml
+++ b/pipelines/upgrade_pipeline.yml
@@ -208,6 +208,7 @@
     - vars/install_base.yml
     - vars/{{ pipeline_type }}_base.yml
   vars:
+    pytest_project_junit_output: /tmp/smoker-junit.xml
     smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"


### PR DESCRIPTION
This allows CentOS CI to actually collect it.