### PR TITLE
Increase resources for stable box and fix hostname env var issue

### DIFF
--- a/packer/centos7-katello-devel-stable.json
+++ b/packer/centos7-katello-devel-stable.json
@@ -2,7 +2,7 @@
     "variables": {
         "user": "vagrant",
         "password": "vagrant",
-        "hostname": "centos7-katello-devel-stable.example.com"
+        "packer_hostname": "centos7-katello-devel-stable.example.com"
    },
 
     "builders":
@@ -24,8 +24,8 @@
             "boot_wait": "2s",
             "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
             "qemuargs": [
-                [ "-m", "8192M" ],
-                [ "-smp", "2" ]
+                [ "-m", "12G" ],
+                [ "-smp", "4" ]
             ],
             "boot_command": [
               "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
@@ -41,7 +41,7 @@
               "scripts/vagrant.sh",
               "scripts/fix_hostname.sh"
             ],
-            "environment_vars": [ "HOSTNAME={{user `hostname`}}" ]
+            "environment_vars": [ "PACKER_HOSTNAME={{user `packer_hostname`}}" ]
 
         },
         {

--- a/packer/scripts/fix_hostname.sh
+++ b/packer/scripts/fix_hostname.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo "Configuring HOSTNAME: $HOSTNAME"
-hostnamectl set-hostname $HOSTNAME
+echo "Configuring HOSTNAME: $PACKER_HOSTNAME"
+hostnamectl set-hostname $PACKER_HOSTNAME
 SHORT_HOSTNAME=$(hostname -s)
-sed -i "1i127.0.0.1 $HOSTNAME $SHORT_HOSTNAME" /etc/hosts
-echo "HOSTNAME $HOSTNAME configured"
+sed -i "1i127.0.0.1 $PACKER_HOSTNAME $SHORT_HOSTNAME" /etc/hosts
+echo "HOSTNAME $PACKER_HOSTNAME configured"


### PR DESCRIPTION
This does two things:

- Increases resources allocated for building the stable box. There are intermittent failures of building the stable box and I believe it is resource related. Note this is not the cores/RAM that will be on the box when spun up, that is set up by the box config (its roughly 9GB of RAM currently in the example file), this commit changes the resources packer uses when building the box.
- Update HOSTNAME environment variable when changing the hostname before installing Katello. Since $HOSTNAME is already a set environment variable, we should use a custom environment variable to set this. This hasn't seemed to cause any issues yet, but I noticed an error when I was playing with custom certificates.

This can be tested out using the instructions in `packer/README.md` with the branch checked out