### PR TITLE
Set etc_hosts for smoker and collect junit

### DIFF
--- a/pipelines/install_pipeline.yml
+++ b/pipelines/install_pipeline.yml
@@ -97,11 +97,12 @@
     - vars/install_base.yml
     - vars/{{ pipeline_type }}_base.yml
   vars:
-    pytest_project_junit_output: /tmp/smoker-junit.xml
     smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   roles:
+    - role: etc_hosts
+      become: true
     - role: epel_repositories
       become: true
     - smoker

--- a/pipelines/upgrade_pipeline.yml
+++ b/pipelines/upgrade_pipeline.yml
@@ -208,11 +208,12 @@
     - vars/install_base.yml
     - vars/{{ pipeline_type }}_base.yml
   vars:
-    pytest_project_junit_output: /tmp/smoker-junit.xml
     smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   roles:
+    - role: etc_hosts
+      become: true
     - role: epel_repositories
       become: true
     - smoker

--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -3,7 +3,8 @@
   become: true
   vars:
     bats_output_dir: '/root/bats_results'
-    bats_remote_dir: '/tmp/debug'
+    remote_dir: '/tmp/debug'
+    smoker_output_dir: '{{ ansible_env.HOME }}/smoker'
   roles:
     - sos_report
   tasks:
@@ -16,5 +17,18 @@
     - name: "Copy bats results"
       fetch:
         src: "{{ item.path }}"
-        dest: "{{ bats_remote_dir }}"
+        dest: "{{ remote_dir }}"
       with_items: "{{ bats_results.files }}"
+
+    - name: "Find smoker files"
+      find:
+        paths: "{{ smoker_output_dir }}"
+        patterns: "*.xml"
+      become: false
+      register: smoker_results
+
+    - name: "Copy smoker results"
+      fetch:
+        src: "{{ item.path }}"
+        dest: "{{ smoker_remote_dir }}"
+      with_items: "{{ smoker_results.files }}"


### PR DESCRIPTION
Previously the smoker output was written, but nothing copied this to the host so nothing was archived.

It also applies the etc_hosts role on the smoker box so it can find the actual servers. Ideally we'd use DNS on the provisioned subnet, but this is a short term fix to proceed.