### PR TITLE
Add a squid box

### DIFF
--- a/playbooks/squid.yml
+++ b/playbooks/squid.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: yes
+  roles:
+    - squid

--- a/roles/squid/tasks/main.yml
+++ b/roles/squid/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Install squid
+  package:
+    name: squid
+    state: present
+
+- name: "Start and enable squid"
+  service:
+    name: squid
+    state: started
+    enabled: yes

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -81,3 +81,18 @@ centos7-katello-devel-stable:
   hostname: centos7-katello-devel-stable.example.com
   ansible:
     playbook: 'playbooks/setup_user_devel_environment.yml'
+
+# This box's intended use is dual homed where one interface is in the
+# management network and the other in an IPv6-only network. If that's using an
+# ULA range or link local, it should have permission to request resources by
+# default. This depends on a manually defined network with a bridge named
+# virbr3.
+centos7-squid:
+  box: centos7
+  ansible:
+    playbook: 'playbooks/squid.yml'
+  networks:
+    - type: 'public_network'
+      options:
+        dev: 'virbr3'
+        type: 'bridge'


### PR DESCRIPTION
The recommended approach with this is to create an isolated network with only IPv6 ULA.

```xml
<network ipv6="yes">
  <name>ipv6-isolated</name>
  <uuid>d3c8973f-b0e6-42a4-a95d-46657fb9bc8c</uuid>
  <bridge name="virbr3" stp="on" delay="0"/>
  <mac address="52:54:00:18:fc:77"/>
  <ip family="ipv6" address="fd00::" prefix="64">
  </ip>
</network>
```

The result is that the Squid box (per example) is in both the management network with IPv4 connectivity and in the ipv6-isolated network with the fd00::/64 ULA network.

I did notice the network sometimes disappeared and I had to manually change the BOOTPROTO from dhcp to none in /etc/sysconfig/network-scripts/ifcfg-eth1. Without that, NetworkManager
took the interface offline when it gave up when IPv4 DHCP failed.

Now a box can be provisioned with only a nic in ipv6-isolated. Since squid out of the box allows ULA networks, it will work out of the box.  On the isolated box, the proxy can be set as follows:

```bash
export http_proxy="http://[fd00::5054:ff:fe72:1e34]:3128"
export https_proxy="http://[fd00::5054:ff:fe72:1e34]:3128"
```

Modify the IP as needed.