### PR TITLE
Hardcode the smoker user's homedir

### DIFF
--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -4,7 +4,7 @@
   vars:
     bats_output_dir: '/root/bats_results'
     remote_dir: '/tmp/debug'
-    smoker_output_dir: '{{ ansible_env.HOME }}/smoker'
+    smoker_output_dir: '/home/vagrant/smoker'
   roles:
     - sos_report
   tasks:
@@ -24,7 +24,6 @@
       find:
         paths: "{{ smoker_output_dir }}"
         patterns: "*.xml"
-      become: false
       register: smoker_results
 
     - name: "Copy smoker results"


### PR DESCRIPTION
The smoker directory is in ~/smoker for non-root, but collection runs as root. In our infrastructure it's safe to assume that user is vagrant.