### PR TITLE
Use the correct destination directory

### DIFF
--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -29,5 +29,5 @@
     - name: "Copy smoker results"
       fetch:
         src: "{{ item.path }}"
-        dest: "{{ smoker_remote_dir }}"
+        dest: "{{ remote_dir }}"
       with_items: "{{ smoker_results.files }}"


### PR DESCRIPTION
623ef516264aa07024616599bac2b944cea89c33 refactored the remote directory to be common, but this was missed. Since no results were copied before, this didn't show up. After e29944991e26182ea282c73991396f93437a51ab was merged, results were copied and it started to fail.