### PR TITLE
Do not use decode on subprocess.check_output

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -36,7 +36,7 @@ def get_running_hosts():
         return
 
     cmd = "vagrant status --machine-readable"
-    status = subprocess.check_output(cmd.split(), universal_newlines=True).decode().rstrip()
+    status = subprocess.check_output(cmd.split(), universal_newlines=True).rstrip()
 
     for line in status.split('\n'):
         if len(line.split(',')) == 4:
@@ -65,7 +65,7 @@ def list_running_hosts():
 def get_ssh_configs(hosts):
     cmd = ['vagrant', 'ssh-config'] + hosts
     try:
-        output = subprocess.check_output(cmd, universal_newlines=True, stderr=DEVNULL).decode()
+        output = subprocess.check_output(cmd, universal_newlines=True, stderr=DEVNULL)
     except subprocess.CalledProcessError:
         return None
 
@@ -85,7 +85,7 @@ def get_host_ssh_config(config, host):
 def get_variables(hosts):
     cmd = [os.path.join(os.path.dirname(os.path.dirname(__file__)), 'bin', 'ansible-vars')] + hosts
     try:
-        output = subprocess.check_output(cmd, universal_newlines=True, stderr=DEVNULL).decode()
+        output = subprocess.check_output(cmd, universal_newlines=True, stderr=DEVNULL)
     except subprocess.CalledProcessError:
         return {}
 


### PR DESCRIPTION
The argument universal_newlines is passed in which means it returns strings rather than bytes. That means there is no decode().

Output with Python 3.7.5 as /usr/bin/python before this patch:

    [WARNING]:  * Failed to parse /home/ekohl/dev/forklift/inventories/vagrant.py with script plugin: Inventory script (/home/ekohl/dev/forklift/inventories/vagrant.py) had an execution
    error: Traceback (most recent call last):   File "/home/ekohl/dev/forklift/inventories/vagrant.py", line 119, in <module>     main()   File
    "/home/ekohl/dev/forklift/inventories/vagrant.py", line 111, in main     hosts = list_running_hosts()   File "/home/ekohl/dev/forklift/inventories/vagrant.py", line 52, in
    list_running_hosts     hosts = list(get_running_hosts())   File "/home/ekohl/dev/forklift/inventories/vagrant.py", line 39, in get_running_hosts     status =
subprocess.check_output(cmd.split(), universal_newlines=True).decode().rstrip() AttributeError: 'str' object has no attribute 'decode'