### PR TITLE
Add Foreman smoker box

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,7 @@ This covers how to setup and configure a development environment using the Forkl
  * [Capsule Development](#capsule-development)
  * [Client Development](#client-development)
  * [Dynflow](#dynflow-development)
+ * [Smoker](#smoker)
 
 ## Development Environment Deployment
 
@@ -379,3 +380,15 @@ vagrant up centos7-dynflow-devel
 ```
 
 In the vagrant box, the dynflow repository is cloned to `/home/vagrant/dynflow`.
+
+## Smoker
+
+The testing tool [smoker](https://github.com/theforeman/smoker) can be set up with the `centos7-foreman-smoker` box and tests can be run against a separate Foreman/Katello instance.
+
+To use:
+1. Ensure that you have a running instance of Foreman/Katello.  
+2. Follow the example box definition in `vagrant/boxes.d/99-local.yaml.example` for `centos7-foreman-smoker` and update the `smoker_base_url` variable. With `pytest_run_tests` set to false, smoker tests will not be run by the playbook, but the box will be set up with pytest and the smoker repository will be cloned to the `vagrant` user's home directory.
+3. Run `vagrant up centos7-foreman-smoker`. A debug message will print showing the command to run smoker tests and the alias that has been set up. The alias is defined in `~/.bash_profile` on the box itself.
+4. You can then ssh into the smoker box. Ensure the hostname of the Foreman/Katello instance can be reached by the smoker box.
+5. From the smoker box, run tests as the vagrant user using the alias or running pytest commands manually. To change the testing options, please see [the smoker documentation](https://github.com/theforeman/smoker) and modify the alias or manually run pytest commands as necessary.
+

--- a/playbooks/smoker.yml
+++ b/playbooks/smoker.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  roles:
+    - role: epel_repositories
+      become: true
+    - role: etc_hosts
+      become: true
+    - smoker

--- a/roles/pytest_project/defaults/main.yml
+++ b/roles/pytest_project/defaults/main.yml
@@ -19,3 +19,5 @@ pytest_project_junit_output: junit.xml
 pytest_project_markers:
 pytest_project_command_args:
 pytest_project_ignore_errors: no
+pytest_run_tests: true
+pytest_project_alias: ""

--- a/roles/pytest_project/tasks/local_env.yml
+++ b/roles/pytest_project/tasks/local_env.yml
@@ -1,0 +1,14 @@
+- name: "Create alias for testing command"
+  lineinfile: 
+    dest: ~/.bash_profile 
+    line: "alias {{ pytest_project_alias }}=\"{{ pytest_project_command }}\""
+  when: pytest_project_alias != ""
+
+- debug:
+    msg: |
+      pytest is installed and testing can be run with
+      {{ pytest_project_command }}
+
+- debug:
+    msg: "The testing command is aliased as {{ pytest_project_alias }}"
+  when: pytest_project_alias != ""

--- a/roles/pytest_project/tasks/run.yml
+++ b/roles/pytest_project/tasks/run.yml
@@ -13,3 +13,7 @@
   ignore_errors: "{{ pytest_project_ignore_errors }}"
   args:
     chdir: "{{ pytest_project_directory }}"
+  when: pytest_run_tests
+
+- include_tasks: local_env.yml
+  when: not pytest_run_tests

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -96,3 +96,12 @@ centos7-squid:
       options:
         dev: 'virbr3'
         type: 'bridge'
+
+centos7-foreman-smoker:
+  box: centos7
+  ansible:
+    playbook: 'playbooks/smoker.yml'
+    variables:
+      smoker_base_url: "CHANGEME" # For example: "https://centos7-katello-devel-stable.example.com"
+      pytest_project_alias: "foreman_smoker"
+      pytest_run_tests: false


### PR DESCRIPTION
Adds the ability to spin up a box with pytest and smoker and run tests on a foreman/katello instance.



UPDATE: I added tasks to spit out the command and also alias it, so you can ignore the following :)

This currently fails when smoker is run, but smoker will be set up on the box and ready to run when the foreman/katello URL resolves properly.

I think in this case it is actually best to not to run smoker and rather just set it up.

The goal of this box is to have a way for developers to run the tests on a system locally. So I'm leaning towards either printing out the command needed to run or setting up an alias on the box for the expected command. This allows developers to ssh into the box and iterate on smoker tests and/or run them locally if trying to debug a failure in infrastructure.

