### PR TITLE
Increase RAM in centos7-katello-devel-stable

### DIFF
--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -77,7 +77,7 @@ centos7-dynflow-devel:
 
 centos7-katello-devel-stable:
   box_name: katello/katello-devel
-  memory: 9000
+  memory: 12288
   hostname: centos7-katello-devel-stable.example.com
   ansible:
     playbook: 'playbooks/setup_user_devel_environment.yml'


### PR DESCRIPTION
We continually see candlepin and other errors with the current amount of RAM, so lets increase the default to something that is more stable.