### PR TITLE
Use pytest as invocation

### DIFF
--- a/roles/pytest_project/tasks/run.yml
+++ b/roles/pytest_project/tasks/run.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Build command'
   set_fact:
-    pytest_project_command: "{{ pytest_project_virtualenv_path }}/bin/py.test --junit-xml={{ pytest_project_junit_output }} {{ pytest_project_command_args }}"
+    pytest_project_command: "{{ pytest_project_virtualenv_path }}/bin/pytest --junit-xml={{ pytest_project_junit_output }} {{ pytest_project_command_args }}"
 
 - name: 'Limit to markers'
   set_fact:


### PR DESCRIPTION
pytest as a command was introduced in pytest 3.0.0 as the recommended entry point.