### PR TITLE
Enable IPv6 in the pipelines

### DIFF
--- a/pipelines/install_pipeline.yml
+++ b/pipelines/install_pipeline.yml
@@ -21,6 +21,7 @@
     - role: forklift_versions
       scenario: "{{ pipeline_type }}"
       scenario_version: "{{ pipeline_version }}"
+    - role: enable_ipv6
     - role: disable_firewall
     - role: foreman_server_repositories
     - role: update_os_packages

--- a/pipelines/upgrade_pipeline.yml
+++ b/pipelines/upgrade_pipeline.yml
@@ -31,6 +31,7 @@
     - foreman_server_repositories
     - update_os_packages
     - haveged
+    - enable_ipv6
     - disable_firewall
     - foreman_installer
 

--- a/roles/enable_ipv6/tasks/main.yml
+++ b/roles/enable_ipv6/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: "Enable ipv6"
+  sysctl:
+    name: "{{ item }}"
+    value: 0
+  with_items:
+    - net.ipv6.conf.default.disable_ipv6
+    - net.ipv6.conf.all.disable_ipv6


### PR DESCRIPTION
The vagrant box generic/ubuntu1804 disables IPv6 but Redis wants to bind to ::1 and fails to start if unavailable. In the wider ecosystem we're also working on proper IPv6 support and the expected user scenario is that IPv6 support should at least be enabled.