### PR TITLE
Fix missing python(2) binary on fedora

### DIFF
--- a/vagrant/boxes.d/03-packaging.yaml
+++ b/vagrant/boxes.d/03-packaging.yaml
@@ -3,4 +3,6 @@ rpm-packaging:
   box: fedora30
   ansible:
     playbook: 'playbooks/rpm_packaging.yml'
+    variables:
+      ansible_python_interpreter: "/usr/bin/python3"
 ...


### PR DESCRIPTION
Relates to #1035
Apparently fedora dropped python2 in the default installation and therefore requires ansible to use python3.

Also vagrant cannot set the hostname for recent Fedora-boxes successfully when vagrant version < 2.1 (see https://github.com/hashicorp/vagrant/issues/8650), but vagrant is to be blamed for that :stuck_out_tongue_winking_eye: 
The problem there was vagrant tried to `service network restart`, but has to do `systemctl restart NetworkManager` 