### PR TITLE
Turning off verify ssl for hammer devel box

### DIFF
--- a/roles/hammer_credentials/defaults/main.yml
+++ b/roles/hammer_credentials/defaults/main.yml
@@ -2,4 +2,4 @@
 hammer_credentials_username: admin
 hammer_credentials_password: "{{ foreman_installer_admin_password | default('changeme') }}"
 hammer_credentials_host: "https://{{ ansible_fqdn | default('localhost') }}"
-hammer_credentials_verify_ssl: true
+hammer_credentials_verify_ssl: false


### PR DESCRIPTION
After spinning up a devel box, you either have to set this manually or trust the certs. I don't see a huge reason to have it on and it makes the box harder to use. This commit turns verify-ssl off.