### PR TITLE
Tune the Puppetserver in the devel scenario

### DIFF
--- a/roles/foreman_installer_devel_scenario/files/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel-answers.yaml
@@ -29,6 +29,10 @@ puppet:
   server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+  # Tune the server for a minimal deployment
+  puppet_server_jvm_max_heap_size: 1G
+  puppet_server_jvm_min_heap_size: 1G
+  puppet_server_max_active_instances: 1
 foreman_proxy::plugin::pulp:
   enabled: true
   pulpnode_enabled: false


### PR DESCRIPTION
This tunes the Puppetserver for a minimal deployment where very few to no clients are expected. This keeps the memory usage of the devel box a bit in check. By doing this via the default answers file, it shouldn't affect users who've already specified other options on the command line.