### PR TITLE
Run smoker verbose to get full diffs

### DIFF
--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -5,7 +5,7 @@ smoker_directory: "{{ ansible_env.HOME }}/smoker"
 smoker_variables: {}
 smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
-smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}'"
+smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' -vv"
 smoker_markers:
 smoker_browser_packages:
   - chromium


### PR DESCRIPTION
Without this, the diffs get shortened which makes them hard to use:

    AssertionError: Error messages with log level SEVERE in browser console assert ['https://pip...con' of null"] == []   Left contains 2 more items, first extra item: 'https://pipeline-foreman-server-nightly-centos7.n59.example.com/webpack/foreman-vendor.bundle-v4.0.7-production-ed656...rver-nightly-centos7.n59.example.com/webpack/foreman-vendor.bundle-v4.0.7-production-ed656fd12ee634eae9b9.js:329:3878)'   Use -v to get the full diff