### PR TITLE
Fix ansible variable leaking

### DIFF
--- a/bin/ansible-vars
+++ b/bin/ansible-vars
@@ -11,4 +11,4 @@ loader.load!
 
 names = $*
 boxes = names.any? ? loader.boxes.select { |name, box| names.include?(name) } : loader.boxes
-puts Hash[boxes.map { |name, box| [name, (box['ansible'] || {})['variables'] || {}] }].to_json
+puts Hash[boxes.map { |name, box| [name, box.dig('ansible', 'variables') || {}] }].to_json


### PR DESCRIPTION
Without this, the variables is a shared hash between boxes that share the same base box. This means that variables can leak into other boxes.