### PR TITLE
Revert use of dig which is Ruby 2.3+ only

### DIFF
--- a/bin/ansible-vars
+++ b/bin/ansible-vars
@@ -11,4 +11,4 @@ loader.load!
 
 names = $*
 boxes = names.any? ? loader.boxes.select { |name, box| names.include?(name) } : loader.boxes
-puts Hash[boxes.map { |name, box| [name, box.dig('ansible', 'variables') || {}] }].to_json
+puts Hash[boxes.map { |name, box| [name, (box['ansible'] || {})['variables'] || {}] }].to_json

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -87,7 +87,7 @@ module Forklift
       box = clone_hash(base_box)
 
       variables = {}
-      variables = clone_hash(box['ansible']['variables']) if box.dig('ansible', 'variables')
+      variables = clone_hash(box['ansible']['variables']) if box['ansible'] && box['ansible']['variables']
       variables.merge!(
         'foreman_repositories_version' => version['foreman'],
         'foreman_client_repositories_version' => version['foreman'],


### PR DESCRIPTION
CI systems are CentOS 7 based and thus Ruby 2.0.