### PR TITLE
Use default verbosity and display started tasks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,7 @@
 callback_whitelist = profile_tasks,profile_roles
 stdout_callback = yaml
 display_skipped_hosts = false
-verbosity = 1
+show_per_host_start = true
 nocows = 1
 inventory = $PWD/inventories/
 roles_path = ./playbooks/galaxy_roles:./user_playbooks/roles:./roles


### PR DESCRIPTION
Especially for CI, dropping verbosity back to normal levels should make more concise output when parsing on CI. Further, the enabling of start task output can be useful to know what step something is at when it appears to be sitting for some period of time. Example output:


```
TASK [foreman_repositories : Remove foreman-release] **************************************************************************************************************************************************************
ok: [pipeline-katello-server-nightly-centos7]
ok: [pipeline-katello-proxy-nightly-centos7]
Thursday 12 March 2020  08:03:39 -0400 (0:00:00.510)       0:00:41.801 ******** 
Thursday 12 March 2020  08:03:39 -0400 (0:00:00.510)       0:00:41.801 ******** 
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Koji repository on pipeline-katello-server-nightly-centos7]
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Koji repository on pipeline-katello-proxy-nightly-centos7]

TASK [foreman_repositories : Foreman nightly Koji repository] *****************************************************************************************************************************************************
ok: [pipeline-katello-proxy-nightly-centos7]
ok: [pipeline-katello-server-nightly-centos7]
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.474)       0:00:42.276 ******** 
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.474)       0:00:42.276 ******** 
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Plugins Koji repository on pipeline-katello-server-nightly-centos7]
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Plugins Koji repository on pipeline-katello-proxy-nightly-centos7]

TASK [foreman_repositories : Foreman nightly Plugins Koji repository] *********************************************************************************************************************************************
ok: [pipeline-katello-server-nightly-centos7]
ok: [pipeline-katello-proxy-nightly-centos7]
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.305)       0:00:42.581 ******** 
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.305)       0:00:42.581 ******** 
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Rails SCL repository on pipeline-katello-server-nightly-centos7]
 [started TASK: foreman_repositories : Foreman {{ foreman_repositories_version }} Rails SCL repository on pipeline-katello-proxy-nightly-centos7]
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.053)       0:00:42.635 ******** 
Thursday 12 March 2020  08:03:40 -0400 (0:00:00.053)       0:00:42.634 ******** 
 [started TASK: foreman_repositories : Install foreman-release-scl on pipeline-katello-server-nightly-centos7]
 [started TASK: foreman_repositories : Install foreman-release-scl on pipeline-katello-proxy-nightly-centos7]
```