### PR TITLE
Install sos as part of bats

### DIFF
--- a/roles/bats/vars/Debian.yml
+++ b/roles/bats/vars/Debian.yml
@@ -3,3 +3,4 @@ bats_packages:
   - curl
   - ruby
   - git
+  - sosreport

--- a/roles/bats/vars/RedHat.yml
+++ b/roles/bats/vars/RedHat.yml
@@ -5,3 +5,4 @@ bats_packages:
   - git
   - yum-utils
   - podman
+  - sos


### PR DESCRIPTION
This is a work around because Katello client tests detach from
available repositories that sos would be in so we need to install it
before hand. The right solution would be to move client testing
to a separate box or container.