### PR TITLE
Skip katello specific upgrade code

### DIFF
--- a/roles/foreman_installer/tasks/upgrade.yml
+++ b/roles/foreman_installer/tasks/upgrade.yml
@@ -1,6 +1,7 @@
 ---
 - name: 'Stop services'
   command: foreman-maintain service stop
+  when: foreman_installer_scenario != 'foreman'
 
 - name: 'Update packages'
   import_role:
@@ -8,9 +9,11 @@
 
 - set_fact:
     foreman_installer_options_internal_use_only: "{{ [ '--upgrade', '--certs-update-all' ] + foreman_installer_options_internal_use_only }}"
-  when: foreman_installer_version_file['content'] | b64decode is version('2.1', '<')
+  when:
+    - foreman_installer_version_file['content'] | b64decode is version('2.1', '<')
+    - foreman_installer_scenario != 'foreman'
 
 - name: 'Run installer upgrade'
   import_tasks: "install.yml"
   vars:
-    foreman_installer_disable_system_checks: true
+    foreman_installer_disable_system_checks: foreman_installer_scenario != 'foreman'


### PR DESCRIPTION
Foreman has never depended on foreman-maintain and isn't even available on Debian. It also doesn't have --upgrade, --certs-update-all and --disable-system-checks parameters.