### PR TITLE
Fix katello upgrade parameter passing

### DIFF
--- a/roles/foreman_installer/tasks/upgrade.yml
+++ b/roles/foreman_installer/tasks/upgrade.yml
@@ -16,4 +16,4 @@
 - name: 'Run installer upgrade'
   import_tasks: "install.yml"
   vars:
-    foreman_installer_disable_system_checks: foreman_installer_scenario != 'foreman'
+    foreman_installer_disable_system_checks: "{{ foreman_installer_scenario != 'foreman' }}"


### PR DESCRIPTION
35ef518717d6eea3c9d393c27efaa3a7fa63ba82 introduced this, but uses incorrect syntax. It was only tested on Foreman where it evaluates to false. That works there. In the katello case it's actually needed and that broke.