### PR TITLE
Remove duplicate entry in stable dev box template

### DIFF
--- a/packer/centos7-katello-devel-stable.json
+++ b/packer/centos7-katello-devel-stable.json
@@ -20,7 +20,6 @@
             "ssh_username": "{{user `user`}}",
             "ssh_password": "{{user `password`}}",
             "ssh_wait_timeout": "20m",
-            "http_directory": "http",
             "boot_wait": "2s",
             "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
             "qemuargs": [


### PR DESCRIPTION
The removed line is the same as line 19, and it looks like newer versions of packer decide to fail because of the dup entry