### PR TITLE
Do not use verbose foreman-installer logging by default

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -2,7 +2,7 @@
 foreman_installer_additional_packages: []
 foreman_installer_admin_password: changeme
 foreman_installer_skip_installer: False
-foreman_installer_verbose: True
+foreman_installer_verbose: False
 foreman_installer_scenario: foreman
 foreman_installer_scenario_flag: '{{ "--scenario" if foreman_installer_scenario != "" else "" }}'
 foreman_installer_upgrade: False


### PR DESCRIPTION
We should rely on the normal error reporting from the installer for debugging and improve it if it does not meet our needs.