### PR TITLE
load the installer version in (install|upgrade).yml

### DIFF
--- a/roles/foreman_installer/tasks/install.yml
+++ b/roles/foreman_installer/tasks/install.yml
@@ -1,4 +1,6 @@
 ---
+- include_tasks: installer_version.yml
+
 - name: 'Check if foreman_installer_options is a string'
   fail:
     msg: 'foreman_installer_options must be an array'

--- a/roles/foreman_installer/tasks/installer_version.yml
+++ b/roles/foreman_installer/tasks/installer_version.yml
@@ -1,0 +1,7 @@
+- name: 'Read installer version'
+  slurp:
+    src: /usr/share/foreman-installer/VERSION
+  register: foreman_installer_version_file
+
+- debug:
+    msg: "Foreman installer version {{ foreman_installer_version_file['content'] | b64decode }}"

--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -1,14 +1,6 @@
 ---
 - include_tasks: packages.yml
 
-- name: 'Read installer version'
-  slurp:
-    src: /usr/share/foreman-installer/VERSION
-  register: foreman_installer_version_file
-
-- debug:
-    msg: "Foreman installer version {{ foreman_installer_version_file['content'] | b64decode }}"
-
 - include_tasks: locales.yml
   when: ansible_os_family == 'Debian'
 

--- a/roles/foreman_installer/tasks/upgrade.yml
+++ b/roles/foreman_installer/tasks/upgrade.yml
@@ -7,6 +7,8 @@
   import_role:
     name: update_os_packages
 
+- include_tasks: installer_version.yml
+
 - set_fact:
     foreman_installer_options_internal_use_only: "{{ [ '--upgrade', '--certs-update-all' ] + foreman_installer_options_internal_use_only }}"
   when:


### PR DESCRIPTION
loading it in main.yml implied we always call main.yml, but this is not
true in the proxy upgrade scenario where the proxy role calls
install.yml only