### PR TITLE
use shorter hostnames for upgrade boxes

### DIFF
--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -1,6 +1,6 @@
 forklift_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_server_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_proxy_name: "pipeline-upgrade-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_server_name: "pipeline-up-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_proxy_name: "pipeline-up-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_smoker_name: "pipeline-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 forklift_boxes: "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"
 smoker_box:

--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -1,7 +1,7 @@
 forklift_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_server_name: "pipeline-up-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_proxy_name: "pipeline-up-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_smoker_name: "pipeline-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_smoker_name: "pipeline-up-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 forklift_boxes: "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"
 smoker_box:
   box: centos7


### PR DESCRIPTION
otherwise they end up longer than allowed in some cases:

    pipeline-upgrade-katello-proxy-nightly-centos7.kangae.example.com