### PR TITLE
k_client: allow ignoring sub-man errors

### DIFF
--- a/roles/katello_client/defaults/main.yml
+++ b/roles/katello_client/defaults/main.yml
@@ -9,3 +9,4 @@ katello_client_extra_repos: []
 katello_client_insecure: False
 katello_client_install_agent: False
 katello_client_install_tracer: False
+katello_client_ignore_registration_errors: False

--- a/roles/katello_client/tasks/main.yml
+++ b/roles/katello_client/tasks/main.yml
@@ -16,6 +16,7 @@
     username: "{{ katello_client_username }}"
     password: "{{ katello_client_password }}"
     server_insecure: "{{ katello_client_insecure }}"
+  ignore_errors: "{{ katello_client_ignore_registration_errors }}"
   when:
     - katello_client_activationkey == ""
 
@@ -25,6 +26,7 @@
     org_id: "{{ katello_client_organization }}"
     activationkey: "{{ katello_client_activationkey }}"
     server_insecure: "{{ katello_client_insecure }}"
+  ignore_errors: "{{ katello_client_ignore_registration_errors }}"
   when:
     - katello_client_activationkey != ""
 


### PR DESCRIPTION
this is required for hosts that get their content via org_environment
mode, but don't have sub-man 1.24.14 (yet).

see https://bugzilla.redhat.com/show_bug.cgi?id=1591315 for details