### PR TITLE
Use nodejs 12 in Katello devel

### DIFF
--- a/roles/nodejs_scl/defaults/main.yml
+++ b/roles/nodejs_scl/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-nodejs_scl_version: rh-nodejs10
+nodejs_scl_version: rh-nodejs12


### PR DESCRIPTION
Seems to be working for that step:

TASK [nodejs_scl : Install NodeJS SCL] *****************************************
changed: [centos7-katello-devel]
