### PR TITLE
HostManager - choose interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ allows completely automated dns resolution using dnsmasq from host to guest and 
 
 You can disable hostmanager in `vagrant/settings.yaml` by setting `hostmanager_enabled` option.
 
+When using a briged network or with multiple network interfaces, the hostmanager would resolve the internal ip from the ssh-info, you can choose an ip of a particular network interface in `vagrant/settings.yaml` by setting `hostmanager_ip_resolver_device` option with the device name.
+
+```yaml
+hostmanager_ip_resolver_device: 'eth1'
+```
+
 ### Adding Custom Boxes
 
 Sometimes you want to spin up the same box type (e.g. centos7-katello-devel) from within the forklift directory. While this can be added to the Vagrantfile directly, updates to the forklift repository could wipe out your local changes. To help with this, you can define a custom box re-using the configuration within the Vagrantfile. To do so, create a `99-local.yaml` file in vagrant/boxes.d/. For example, to create a custom box on CentOS 7 with nightly and run the installers reset command:

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -130,6 +130,18 @@ module Forklift
       config.hostmanager.manage_host = true
       config.hostmanager.manage_guest = true
       config.hostmanager.include_offline = true
+
+      return unless (dev = @settings['hostmanager_ip_resolver_device'])
+
+      config.hostmanager.ip_resolver = proc do |vm|
+        if vm.ssh_info && vm.ssh_info[:host]
+          result = ''
+          vm.communicate.execute("ip addr show #{dev}") do |type, data|
+            result = "#{result}#{data}" if type == :stdout
+          end
+          (ip = /inet (\d+\.\d+\.\d+\.\d+)/.match(result)) && ip[1]
+        end
+      end
     end
 
     def configure_vagrant_cachier(config)

--- a/vagrant/settings.yaml.example
+++ b/vagrant/settings.yaml.example
@@ -12,6 +12,10 @@ ssh_forward_agent: True
 
 domain: 'example.com'
 
+# define the hostmanager plugin to get the ip from a chosen network interface
+# usefull when using briged network
+# hostmanager_ip_resolver_device: 'eth1'
+
 # https://github.com/mitchellh/vagrant-google
 google_project_id: "YOUR_GOOGLE_CLOUD_PROJECT_ID"
 google_client_email: "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"


### PR DESCRIPTION
When using the HostManager plugin,
let the user choose which device interface to
use to resolve the ip in the hostfile.