### PR TITLE
move box exclusion to an own function and call it once

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -163,6 +163,7 @@ module Forklift
       end
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def configure_ansible(machine, ansible, box_name)
       return unless ansible
 
@@ -189,6 +190,7 @@ module Forklift
         end
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def configure_shell(machine, box)
       return unless box.key?('shell') && !box['shell'].nil?

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -30,10 +30,11 @@ module Forklift
     end
 
     def filter_boxes!
-      box_config = Settings.new.settings.key?('boxes') ? Settings.new.settings['boxes'] : {}
+      box_config = Settings.new.settings['boxes']
+      return unless box_config&.key?('exclude')
 
       @boxes.reject! do |name, _box|
-        box_config.key?('exclude') && box_config['exclude'].any? { |exclude| name.match(/#{exclude}/) }
+        box_config['exclude'].any? { |exclude| name.match(/#{exclude}/) }
       end
     end
 

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -29,6 +29,14 @@ module Forklift
       end
     end
 
+    def filter_boxes!
+      box_config = Settings.new.settings.key?('boxes') ? Settings.new.settings['boxes'] : {}
+
+      @boxes.reject! do |name, _box|
+        box_config.key?('exclude') && box_config['exclude'].any? { |exclude| name.match(/#{exclude}/) }
+      end
+    end
+
     private
 
     def load_box_file(file)
@@ -38,10 +46,6 @@ module Forklift
 
     def process_boxes!(boxes)
       boxes.each do |name, box|
-        box_config = Settings.new.settings.key?('boxes') ? Settings.new.settings['boxes'] : {}
-
-        next if box_config.key?('exclude') && box_config['exclude'].any? { |exclude| name.match(/#{exclude}/) }
-
         box = layer_base_box(box)
         box['name'] = name
 

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -31,8 +31,10 @@ module Forklift
 
     def filter_boxes!
       box_config = Settings.new.settings['boxes']
-      return unless box_config&.key?('exclude')
+      # rubocop:disable Style/SafeNavigation
+      return unless box_config && box_config.key?('exclude')
 
+      # rubocop:enable Style/SafeNavigation
       @boxes.reject! do |name, _box|
         box_config['exclude'].any? { |exclude| name.match(/#{exclude}/) }
       end

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -15,6 +15,7 @@ module Forklift
       @locations.sort_by { |f| File.basename(f) }.each do |box_file|
         @box_factory.add_boxes!(box_file)
       end
+      @box_factory.filter_boxes!
     end
 
     def boxes

--- a/vagrant/test/lib/box_loader_test.rb
+++ b/vagrant/test/lib/box_loader_test.rb
@@ -10,8 +10,22 @@ class TestBoxLoader < Minitest::Test
     loader.load!
 
     assert loader.boxes
+    assert loader.boxes['centos7-katello-nightly']
     assert_equal 'centos7-katello-nightly', loader.boxes['centos7-katello-nightly']['name']
     assert_equal 'centos/7', loader.boxes['centos7-katello-nightly']['box_name']
+  end
+
+  def test_load_with_exclude
+    excludes = { 'boxes' => { 'exclude' => ['fedora'] } }
+    Forklift::Settings.any_instance.stubs(:settings).returns(excludes)
+    locations = get_locations('00-fedora.yaml', '03-packaging.yaml')
+    loader = Forklift::BoxLoader.new(nil, locations)
+    loader.load!
+
+    assert loader.boxes
+    assert loader.boxes['rpm-packaging']
+    assert_equal 'rpm-packaging', loader.boxes['rpm-packaging']['name']
+    assert_equal 'fedora/30-cloud-base', loader.boxes['rpm-packaging']['box_name']
   end
 
   private


### PR DESCRIPTION
if we filter in `process_boxes!`, we might also filter out our base
boxes and then our real boxes end up without a `box_name` and thus can't
be created by vagrant at all.

instead let's reject all excluded boxes in a separate step