### PR TITLE
minor changes to Ansible instructions

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -71,7 +71,7 @@ This use case assumes that you are on a box that has SSH access to the target bo
 
 For a release version in production:
 
-    ansible-playbook -l <target-host> playbooks/katello.yml -e foreman_repositories_version=1.17 -e katello_repositories_version=3.6
+    ansible-playbook -l <target-host> playbooks/katello.yml -e foreman_repositories_version=VERSIONYOUWANT -e katello_repositories_version=VERSIONYOUWANT
 
 For nightly production:
 
@@ -85,13 +85,14 @@ After installing a Katello server, you could then spin up a Capsule with the ass
 ### Local Deployment
 
 1. ssh to target machine **as root**
-2. Install Ansible -- `yum install ansible`
+2. Install Ansible -- `yum install ansible` (this will require the EPEL repo)
 3. Clone this repository - `git clone https://github.com/theforeman/forklift.git`
 4. Enter the repository - `cd forklift`
+5. Make sure DNS is set up properly. This is a Foreman requirement, not an Ansible requirement.
 
 For a release version in production:
 
-    ansible-playbook -l localhost playbooks/katello.yml -e foreman_repositories_version=1.17 -e katello_repositories_version=3.6
+    ansible-playbook -l localhost playbooks/katello.yml -e foreman_repositories_version=VERSIONYOUWANT -e katello_repositories_version=VERSIONYOUWANT
 
 For nightly production:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -52,7 +52,7 @@ Start the installation for CentOS 7:
 
     vagrant up centos7-katello-3.4
 
-
+This will create a libvirt based virtual machine running the Katello server on CentOS.
 
 ## BYOB
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -85,7 +85,7 @@ After installing a Katello server, you could then spin up a Capsule with the ass
 ### Local Deployment
 
 1. ssh to target machine **as root**
-2. Install Ansible -- `yum install ansible` (this will require the EPEL repo)
+2. Install Ansible -- `yum install ansible` (for example from the EPEL repo)
 3. Clone this repository - `git clone https://github.com/theforeman/forklift.git`
 4. Enter the repository - `cd forklift`
 5. Make sure DNS is set up properly. This is a Foreman requirement, not an Ansible requirement.

--- a/docs/production.md
+++ b/docs/production.md
@@ -52,7 +52,7 @@ Start the installation for CentOS 7:
 
     vagrant up centos7-katello-3.4
 
-This will create a libvirt based virtual machine running the Katello server on CentOS.
+This will create a libvirt based virtual machine running the Katello server on CentOS. 
 
 
 ## BYOB
@@ -68,10 +68,11 @@ This use case assumes that you are on a box that has SSH access to the target bo
 3. Enter the repository - `cd forklift`
 4. [Create an inventory file](https://docs.ansible.com/ansible/latest/intro_inventory.html) with your hosts in the `inventories` subfolder. You can also pass a different inventory to `ansible-playbook` using `--inventory` or `-i`.
 5. Change the variable remote_user in ./ansible.cfg to the appropriate value (the user that will log into the remote machine)
+6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://www.theforeman.org/plugins/katello/3.16/installation/index.html. Replace the 3.16 in the URL with whatever version of Katello you want to install.
 
 For a release version in production:
 
-    ansible-playbook -l <target-host> playbooks/katello.yml -e foreman_repositories_version=VERSIONYOUWANT -e katello_repositories_version=VERSIONYOUWANT
+    ansible-playbook -l <target-host> playbooks/katello.yml -e foreman_repositories_version=WANTED_FOREMAN_VERSION -e katello_repositories_version=WANTED_KATELLO_VERSION
 
 For nightly production:
 
@@ -89,6 +90,7 @@ After installing a Katello server, you could then spin up a Capsule with the ass
 3. Clone this repository - `git clone https://github.com/theforeman/forklift.git`
 4. Enter the repository - `cd forklift`
 5. Make sure DNS is set up properly. This is a Foreman requirement, not an Ansible requirement.
+6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://www.theforeman.org/plugins/katello/3.16/installation/index.html. Replace the 3.16 in the URL with whatever version of Katello you want to install.
 
 For a release version in production:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -92,7 +92,7 @@ After installing a Katello server, you could then spin up a Capsule with the ass
 
 For a release version in production:
 
-    ansible-playbook -l localhost playbooks/katello.yml -e foreman_repositories_version=VERSIONYOUWANT -e katello_repositories_version=VERSIONYOUWANT
+    ansible-playbook -l localhost playbooks/katello.yml -e foreman_repositories_version=WANTED_FOREMAN_VERSION -e katello_repositories_version=WANTED_KATELLO_VERSION
 
 For nightly production:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -52,7 +52,6 @@ Start the installation for CentOS 7:
 
     vagrant up centos7-katello-3.4
 
-This will create a libvirt based virtual machine running the Katello server on CentOS. 
 
 
 ## BYOB
@@ -68,7 +67,7 @@ This use case assumes that you are on a box that has SSH access to the target bo
 3. Enter the repository - `cd forklift`
 4. [Create an inventory file](https://docs.ansible.com/ansible/latest/intro_inventory.html) with your hosts in the `inventories` subfolder. You can also pass a different inventory to `ansible-playbook` using `--inventory` or `-i`.
 5. Change the variable remote_user in ./ansible.cfg to the appropriate value (the user that will log into the remote machine)
-6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://www.theforeman.org/plugins/katello/3.16/installation/index.html. Replace the 3.16 in the URL with whatever version of Katello you want to install.
+6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://github.com/theforeman/forklift/blob/master/vagrant/config/versions.yaml. Replace the 3.16 in the URL with whatever version of Katello you want to install.
 
 For a release version in production:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -89,7 +89,7 @@ After installing a Katello server, you could then spin up a Capsule with the ass
 3. Clone this repository - `git clone https://github.com/theforeman/forklift.git`
 4. Enter the repository - `cd forklift`
 5. Make sure DNS is set up properly. This is a Foreman requirement, not an Ansible requirement.
-6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://www.theforeman.org/plugins/katello/3.16/installation/index.html. Replace the 3.16 in the URL with whatever version of Katello you want to install.
+6. Determine the compatible versions of Foreman and Katello you want to install based on the Katello install instructions at https://github.com/theforeman/forklift/blob/master/vagrant/config/versions.yaml. Replace the 3.16 in the URL with whatever version of Katello you want to install.
 
 For a release version in production:
 


### PR DESCRIPTION
I don't think tying to a specific version of foreman and katello in the docs is a good idea, unless someone is going to update it for every version. Also, some changes to the local deployment. Obviously, this is not the place for full Ansible instructions, but if people are new to repos, the fact that 'yum install ansible' does not work without EPEL is an easy blocker to avoid.