### PR TITLE
Check hammer ping output for failures

### DIFF
--- a/bats/fb-test-katello.bats
+++ b/bats/fb-test-katello.bats
@@ -15,13 +15,16 @@ load foreman_helper
   fi
 
   local next_wait_time=0
-  until hammer ping; do
-    if [ $next_wait_time -eq 12 ]; then
-      # make one last try, also makes the error nice
-      hammer ping
-    fi
-    sleep $(( next_wait_time++ ))
+  until [ "${status:-1}" -eq 0 -o $next_wait_time -eq 12 ]; do
+    run hammer ping
+    [[ $status -eq 0 ]] || sleep $(( next_wait_time++ ))
   done
+
+  echo "${output}"
+
+  [ $status -eq 0 ]
+
+  [[ $output != *"FAIL"* ]]
 }
 
 @test "check service status" {

--- a/bats/fb-test-katello.bats
+++ b/bats/fb-test-katello.bats
@@ -24,6 +24,8 @@ load foreman_helper
 
   [ $status -eq 0 ]
 
+  # Hammer exits with 0 on failures
+  # https://projects.theforeman.org/issues/30496
   [[ $output != *"FAIL"* ]]
 }
 


### PR DESCRIPTION
We've had some nightly builds get through with the 'candlepin_events' service being broken. This change would catch that and other backend problems