### PR TITLE
Create libvirt boxes with virtio-rng

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -53,6 +53,7 @@ module Forklift
         config.vm.provider :libvirt do |domain|
           domain.memory = @settings['memory']
           domain.cpus   = @settings['cpus']
+          domain.random :model => 'random'
         end
 
         config.vm.provider :virtualbox do |domain|


### PR DESCRIPTION
By creating the VMs with a virtio-rng device, the VMs get access to the host's entropy. This can greatly speed up creation of secrets like private keys for SSH and SSL.

https://github.com/vagrant-libvirt/vagrant-libvirt#random-number-generator-passthrough

This was tested on a CentOS 7 by following https://wiki.qemu.org/Features/VirtIORNG#On_the_guest.

Existing VMs will not be updated, but newly provisioned machines will get the benefits.