### PR TITLE
correctly check whether a CV version has the right environments

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -409,8 +409,8 @@ setup() {
   cvv_id=$(hammer --csv --no-headers content-view version list --organization="${ORGANIZATION}" \
     | grep "${CONTENT_VIEW_2} 1.1" | cut -d, -f1)
   envs_found=$(hammer content-view version info --organization="${ORGANIZATION}" \
-    --id=$cvv_id | grep -E "Name:  Library")
-  echo $envs_found | grep -q "Name: Library"
+    --id=$cvv_id | awk '/Lifecycle Environments/{flag=1;next}/Repositories/{flag=0}flag' | grep "Name:")
+  echo $envs_found | grep -q -E "Name:\s+Library"
 }
 
 @test "ensure composite cv version 1.1 has proper environments" {
@@ -419,8 +419,9 @@ setup() {
   cvv_id=$(hammer --csv --no-headers content-view version list --organization="${ORGANIZATION}" \
     | grep "${CONTENT_VIEW_3} 1.1" | cut -d, -f1)
   envs_found=$(hammer content-view version info --organization="${ORGANIZATION}" \
-    --id=$cvv_id | grep -E "Name:  Library|Name:  ${LIFECYCLE_ENVIRONMENT}")
-  echo $envs_found | grep -q "Name: Library Name: ${LIFECYCLE_ENVIRONMENT}"
+    --id=$cvv_id | awk '/Lifecycle Environments/{flag=1;next}/Repositories/{flag=0}flag' | grep "Name:")
+  echo $envs_found | grep -q -E "Name:\s+Library"
+  echo $envs_found | grep -q -E "Name:\s+${LIFECYCLE_ENVIRONMENT}"
 }
 
 @test "ensure component cv 1 latest version has proper content" {


### PR DESCRIPTION
the grep patterns for `$envs_found` were wrong before this: the number
of spaces was off and in the two environment case it was missing the OR
operator

this change introduces the following:
1. the CV version info (to be stored in `$envs_found`) is filtered to
   contain only the LE data, not Repositories etc (which could be called
   Library too)
2. the grep patterns now accept any number of spaces between "Name:" and
   the actual LE name
3. in the two LE case both LEs are tested separately to ensure the CV
   version is really in both (and not only in one) of them