### PR TITLE
Install centos-release-scl-rh rpm only for CentOS

### DIFF
--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -9,7 +9,7 @@
   tags:
     - packages
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_distribution == 'CentOS'
     - ansible_distribution_major_version == '7'
 
 - name: 'Clean yum'


### PR DESCRIPTION
There is no `centos-release-scl-rh` on RHEL7 so install it only for CentOS

For RHEL7 we can enable scl repo before playbook run (for now) and later there could be scl task for it.