### PR TITLE
Allow use of foreman-installer PR

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -19,6 +19,9 @@ foreman_installer_module_prs_strategy: "merge"
 # Comma-separated list of "organization/module/branch", e.g. "theforeman/foreman/foo,theforeman/katello/bar"
 foreman_installer_module_branches: []
 
+foreman_installer_from_source: False
+foreman_installer_git_pr_number:
+
 # There are two options, so a user can supply their own, and a playbook can
 # specify theirs. For example, foreman-proxy needs "--foreman-proxy-foreman-url"
 # so we put it in internal_use_only in a role or playbook.

--- a/roles/foreman_installer/tasks/install.yml
+++ b/roles/foreman_installer/tasks/install.yml
@@ -22,6 +22,15 @@
     - { new: '--foreman-initial-admin-password', old: '--foreman-admin-password' }
     - { new: '--foreman-initial-admin-username', old: '--foreman-admin-username' }
 
+- name: 'Replace installer command when using installer source'
+  set_fact:
+    foreman_installer_command: scl enable {{ scl_ruby_version.stdout }} -- bundle exec bin/foreman-installer
+  when: foreman_installer_from_source == True
+
+- name: 'setup puppetserver ca'
+  shell: /opt/puppetlabs/bin/puppetserver ca setup
+  when: foreman_installer_from_source == True
+
 - name: 'Run installer'
   shell: >
       {{ foreman_installer_command }} {{ (foreman_installer_verbose|bool) | ternary("-v", "") }}
@@ -30,5 +39,7 @@
       {{ foreman_installer_scenario_flag }} {{ foreman_installer_scenario }}
       {{ foreman_installer_options_joined }}
   when: not foreman_installer_skip_installer
+  args:
+    chdir: /usr/share/foreman-installer/
   tags:
     - installation

--- a/roles/foreman_installer/tasks/installer_from_source.yml
+++ b/roles/foreman_installer/tasks/installer_from_source.yml
@@ -1,0 +1,53 @@
+---
+- name: "clone foreman-installer repository"
+  git:
+    repo: https://github.com/theforeman/foreman-installer.git
+    dest: "/usr/share/foreman-installer"
+    force: yes
+
+- name: "checkout foreman-installer PR"
+  shell: >
+      git fetch origin pull/{{ foreman_installer_git_pr_number }}/head:pr &&
+      git checkout pr
+  args:
+    chdir: "/usr/share/foreman-installer"
+  when: foreman_installer_git_pr_number is defined and foreman_installer_git_pr_number
+
+- name: "ensure ruby-augeas in Gemfile"
+  lineinfile:
+    path: /usr/share/foreman-installer/Gemfile
+    line: gem 'ruby-augeas'
+
+- name: "ensure oauth in Gemfile"
+  lineinfile:
+    path: /usr/share/foreman-installer/Gemfile
+    line: gem 'oauth'
+
+- name: "bundle install"
+  shell: scl enable {{ scl_ruby_version.stdout }} -- bundle install
+  args:
+    chdir: "/usr/share/foreman-installer"
+
+- name: "build installer"
+  shell: scl enable {{ scl_ruby_version.stdout }} -- bundle exec rake build
+  args:
+    chdir: "/usr/share/foreman-installer"
+
+- name: 'Ensure /etc/foreman-installer'
+  file:
+    state: directory
+    path: /etc/foreman-installer
+
+- name: 'Ensure /var/log/redis'
+  file:
+    state: directory
+    path: /var/log/redis
+
+- name: 'Apply correct selinux file context to /var/log/redis'
+  command: restorecon -v /var/log/redis
+
+- name: 'Symlink custom-hiera.yaml'
+  file:
+    src: /usr/share/foreman-installer/config/custom-hiera.yaml
+    dest: /etc/foreman-installer/custom-hiera.yaml
+    state: link

--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -1,8 +1,16 @@
 ---
+- name: "build installer from source when installer PR is specified"
+  set_fact:
+    foreman_installer_from_source: True
+  when: foreman_installer_git_pr_number is defined and foreman_installer_git_pr_number
+
 - include_tasks: packages.yml
 
 - include_tasks: locales.yml
   when: ansible_os_family == 'Debian'
+
+- include_tasks: installer_from_source.yml
+  when: foreman_installer_from_source == True
 
 - include_tasks: module_prs.yml
   when: (foreman_installer_module_prs|length > 0) or (foreman_installer_module_branches|length > 0)

--- a/roles/foreman_installer/tasks/packages.yml
+++ b/roles/foreman_installer/tasks/packages.yml
@@ -5,6 +5,7 @@
     state: latest
   tags:
     - packages
+  when: foreman_installer_from_source == False
 
 - name: 'Install additional packages'
   package:
@@ -12,3 +13,24 @@
     state: latest
   tags:
     - packages
+
+- name: "install foreman package (for scl dependency)"
+  package:
+    name: foreman
+    state: 'present'
+  tags:
+    - packages
+  when: foreman_installer_from_source == True
+
+- name: "get ruby scl version"
+  shell: scl --list | grep ruby | head -n1
+  register: scl_ruby_version
+  when: foreman_installer_from_source == True
+
+- name: "install other dependencies to build and run installer from source"
+  package:
+    name: git, {{ scl_ruby_version.stdout }}-ruby-devel, gcc, asciidoc, puppet-agent, puppetserver, augeas-devel
+    state: 'present'
+  tags:
+    - packages
+  when: foreman_installer_from_source == True

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 dependencies:
   - role: foreman
+    foreman_installer_from_source: False
+    foreman_installer_git_pr_number:
     foreman_server_repositories_katello: true
     foreman_server_repositories_ostree: true
     foreman_installer_scenario: katello


### PR DESCRIPTION
This is a very rough draft of an idea to use a foreman-installer PR with forklift

Actually currently it allows any fork and branch to be used, but could be updated to specify a PR number instead

The RPM is still installed but we are doing `git checkout -f` over it which is kind of hackish but I need to figure out a strategy to deal with the `modules/` subdirectory.