### PR TITLE
Fix Ansible warnings

### DIFF
--- a/roles/disable_ipv6/tasks/main.yml
+++ b/roles/disable_ipv6/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: "Disable ipv6"
   sysctl:
     name: "{{ item }}"
-    value: 1
+    value: "1"
   with_items:
     - net.ipv6.conf.default.disable_ipv6
     - net.ipv6.conf.all.disable_ipv6

--- a/roles/enable_ipv6/tasks/main.yml
+++ b/roles/enable_ipv6/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Enable ipv6"
   sysctl:
     name: "{{ item }}"
-    value: 0
+    value: "0"
   with_items:
     - net.ipv6.conf.default.disable_ipv6
     - net.ipv6.conf.all.disable_ipv6

--- a/roles/foreman_repositories/tasks/redhat_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_staging_repos.yml
@@ -17,8 +17,8 @@
     name: foreman-koji
     description: "Foreman {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-{{ foreman_repositories_version }}/RHEL/{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: "1"
+    gpgcheck: "0"
     include: /etc/yum/foreman.conf
   tags:
     - packages
@@ -29,8 +29,8 @@
     state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"
     description: "Foreman Plugins {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-plugins-{{ foreman_repositories_version }}/RHEL/{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: "1"
+    gpgcheck: "0"
     include: /etc/yum/foreman.conf
   tags:
     - packages
@@ -40,8 +40,8 @@
     name: foreman-rails
     description: "Rails SCL for Foreman {{ foreman_repositories_version }}"
     baseurl: "https://yum.theforeman.org/rails/foreman-{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: "1"
+    gpgcheck: "0"
   tags:
     - packages
   when:

--- a/roles/katello_repositories/tasks/main.yml
+++ b/roles/katello_repositories/tasks/main.yml
@@ -5,6 +5,8 @@
 - name: enable pki-core module
   command: dnf module -y enable pki-core
   when: ansible_distribution_major_version == "8"
+  args:
+    warn: false # dnf module can't handle modules
 
   # Required for el6 clients
 - include_tasks: qpid.yml


### PR DESCRIPTION
Ansible warns about these:

```
TASK [enable_ipv6 : Enable ipv6] *****************************************************************************************************************************************************
changed: [pipeline-katello-server-nightly-centos8] => (item=net.ipv6.conf.default.disable_ipv6)
changed: [pipeline-katello-server-nightly-centos8] => (item=net.ipv6.conf.all.disable_ipv6)
[WARNING]: The value 0 (type int) in a string field was converted to '0' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

And also

```
TASK [foreman_repositories : Foreman nightly Koji repository] ************************************************************************************************************************
[WARNING]: The value 1 (type int) in a string field was converted to '1' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

Then there is a false positive for DNF. The Ansible DNF module doesn't
support dnf module so we need to use command.

```
TASK [katello_repositories : enable pki-core module] *********************************************************************************************************************************
[WARNING]: Consider using the dnf module rather than running 'dnf'.  If you need to use command because dnf is insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in ansible.cfg to get rid of this message.
```