### PR TITLE
Re-enable composite cv test and fix content checking

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -476,9 +476,10 @@ setup() {
   cvv_id=$(hammer --csv --no-headers content-view version list --organization="${ORGANIZATION}" \
     | grep "${CONTENT_VIEW_3} 1.1" | cut -d, -f1)
 
-  # Skipping temporarily until Pulp2/Pulp3 differences are resolved
-  #hammer package list --content-view-version-id=$cvv_id --order='name DESC' --fields='filename' > cvv_content
-  #diff cvv_content fixtures/composite_rpms
+  # Sorting and removing duplicates due to Pulp2/Pulp3 differences (https://projects.theforeman.org/issues/30755)
+  hammer package list --content-view-version-id=$cvv_id --order='name DESC' --fields='filename' \
+    | awk '!seen[$0]++' > cvv_content
+  diff -w cvv_content fixtures/composite_rpms
 
   hammer erratum list --content-view-version-id=$cvv_id --order='id' --fields='Errata ID' > cvv_content
   diff cvv_content fixtures/composite_errata

--- a/bats/fixtures/composite_rpms
+++ b/bats/fixtures/composite_rpms
@@ -1,20 +1,14 @@
 -----------------------------
 FILENAME                     
------------------------------
 zebra-0.1-2.noarch.rpm       
 wolf-9.4-2.noarch.rpm        
 whale-0.2-1.noarch.rpm       
-whale-0.2-1.noarch.rpm       
 walrus-0.71-1.noarch.rpm     
-walrus-0.71-1.noarch.rpm     
-walrus-5.21-1.noarch.rpm     
 walrus-5.21-1.noarch.rpm     
 trout-0.12-1.noarch.rpm      
 tiger-1.0-4.noarch.rpm       
 stork-0.12-2.noarch.rpm      
-stork-0.12-2.noarch.rpm      
 squirrel-0.1-1.noarch.rpm    
-shark-0.1-1.noarch.rpm       
 shark-0.1-1.noarch.rpm       
 pike-2.2-1.noarch.rpm        
 penguin-0.9.1-1.noarch.rpm   
@@ -38,4 +32,3 @@ cheetah-1.25.3-5.noarch.rpm
 cat-1.0-1.noarch.rpm         
 camel-0.1-1.noarch.rpm       
 bear-4.1-1.noarch.rpm        
------------------------------


### PR DESCRIPTION
I previously had to disable the composite CV content-checking test because Pulp 2 and Pulp 3 differed.  It turns out that difference only applies to package duplicates, so I've made the check only look at a list of unique packages.

I've tested this on varying Katello production installs with and without Pulp 3 enabled.