### PR TITLE
Add automatic disk resizing when disk_size is specified

### DIFF
--- a/playbooks/resize_disk.yaml
+++ b/playbooks/resize_disk.yaml
@@ -1,0 +1,37 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Find root partition
+      shell: df --output=source,fstype / | tail -n 1
+      register: root_partition
+
+    - name: Install cloud-utils-growpart package
+      package:
+        name: cloud-utils-growpart
+      when: ansible_os_family == 'RedHat'
+
+    - name: Install cloud-guest-utils package
+      package:
+        name: cloud-guest-utils
+      when: ansible_os_family == 'Debian'
+
+    - name: Install e2fsprogs package
+      package:
+        name: e2fsprogs
+      when: '"ext4" in root_partition.stdout'
+
+    - name: Extend partition
+      command: growpart /dev/vda {{ root_partition.stdout.split(' ')[0].replace('/dev/vda', '') }}
+      register: growpart_output
+      failed_when:
+        - growpart_output.rc != 0
+        - '"NOCHANGE" not in growpart_output.stdout'
+
+    - name: Grow XFS filesystem
+      command: xfs_growfs -d /
+      when: '"xfs" in root_partition.stdout'
+
+    - name: Grow ext4 filesystem
+      command: resize2fs {{ root_partition.stdout.split(' ')[0] }}
+      when: '"ext4" in root_partition.stdout'

--- a/vagrant/.rubocop.yml
+++ b/vagrant/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/ClassLength:
-  Max: 300
+  Max: 325
 
 Documentation:
   Enabled: false # don't require documentation

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -82,6 +82,8 @@ module Forklift
                                 "#{box.fetch('name').to_s.tr('.', '-')}.#{domain}"
                               end
 
+        resize_disk(machine) if box.fetch('disk_size', false)
+
         networks = configure_networks(box.fetch('networks', []))
         configure_shell(machine, box)
         configure_ansible(machine, box['ansible'], box['name'])
@@ -96,6 +98,12 @@ module Forklift
         configure_nfs(config, box)
 
         yield machine if block_given?
+      end
+    end
+
+    def resize_disk(machine)
+      machine.vm.provision('disk_resize', type: 'ansible') do |ansible_provisioner|
+        ansible_provisioner.playbook = 'playbooks/resize_disk.yaml'
       end
     end
 


### PR DESCRIPTION
If a box is defined with a larger disk size through the use of
disk_size parameter the user then has to manually resize the filesystem.
With the introduction of CentOS 8, which has a base disk size of
10GB within the image this operation will be prevalent for nearly
all Katello production and development deployments through Vagrant.

This adds automatic disk resizing by running a playbook as a
provisioner if the disk_size parameter is defined.