### PR TITLE
Add centos8-devel box for Katello devel environments on EL8

### DIFF
--- a/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
+++ b/roles/foreman_installer_devel_scenario/files/katello-devel.yaml
@@ -19,6 +19,7 @@
 :facts:
   tuning: default
 :colors: true
+:verbose: true
 :order:
 - certs
 - foreman_proxy

--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -9,12 +9,18 @@
     state: directory
     path: /etc/foreman-installer/scenarios.d
 
-- name: 'Copy scenario files'
+- name: 'Copy scenario file'
   copy:
     src: "{{ role_path }}/files/{{ item }}"
     dest: /etc/foreman-installer/scenarios.d
   with_items:
     - katello-devel.yaml
+
+- name: 'Copy answers file'
+  template:
+    src: "{{ role_path }}/templates/{{ item }}"
+    dest: /etc/foreman-installer/scenarios.d/{{ item }}
+  with_items:
     - katello-devel-answers.yaml
 
 - name: 'Remove current puppet-katello_devel'

--- a/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
@@ -6,17 +6,11 @@ certs:
 katello_devel:
   deployment_dir: /home/vagrant
   user: vagrant
-  db_type: postgres
-  rvm: true
 foreman_proxy_content:
-  pulp_master: true
-  qpid_router_broker_addr: localhost
+  proxy_pulp_yum_to_pulpcore: true
 foreman_proxy:
-  custom_repo: true
   http: true
   ssl_port: '9090'
-  templates: false
-  tftp: false
   ssl_ca: /etc/foreman-proxy/ssl_ca.pem
   ssl_cert: /etc/foreman-proxy/ssl_cert.pem
   ssl_key: /etc/foreman-proxy/ssl_key.pem
@@ -34,7 +28,7 @@ puppet:
   puppet_server_jvm_min_heap_size: 1G
   puppet_server_max_active_instances: 1
 foreman_proxy::plugin::pulp:
-  enabled: true
+  enabled: {{ ansible_distribution_major_version == "7" }}
   pulpnode_enabled: false
   pulpcore_enabled: true
 foreman_proxy::plugin::abrt: false

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -6,8 +6,11 @@ dependencies:
     foreman_server_repositories_katello: true
     foreman_server_repositories_foreman_client: true
   - role: ruby_scl
+    when: ansible_distribution_major_version == "7"
   - role: nodejs_scl
+    when: ansible_distribution_major_version == "7"
   - role: postgresql_scl
+    when: ansible_distribution_major_version == "7"
   - role: foreman_installer_devel_scenario
   - role: foreman_installer
     foreman_installer_scenario: katello-devel
@@ -15,6 +18,6 @@ dependencies:
       - foreman-installer-katello
     foreman_installer_disable_system_checks: true
     foreman_installer_options_internal_use_only:
-      - "--katello-devel-scl-ruby={{ ruby_scl_version }}"
+      - "{{ '--katello-devel-scl-ruby=' +  ruby_scl_version if ansible_distribution_major_version == '7' else '' }}"
       - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"
   - role: customize_home

--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -33,6 +33,7 @@ boxes:
 
   centos8:
     box_name: 'centos/8'
+    disk_size: 40
     pty: true
     scenarios:
       - foreman

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -10,6 +10,19 @@ centos7-katello-devel:
       foreman_devel_github_push_ssh: True
       katello_devel_github_username: <REPLACE ME>
 
+centos8-katello-devel:
+  primary: true
+  box: centos8
+  ansible:
+    playbook: 'playbooks/katello_devel.yml'
+    group: 'devel'
+    variables:
+      ssh_forward_agent: true
+      foreman_devel_github_push_ssh: True
+      katello_devel_github_username: <REPLACE ME>
+      foreman_repositories_environment: staging
+      katello_repositories_environment: staging
+
 centos7-luna-devel:
   box: centos7
   memory: 9000


### PR DESCRIPTION
Requires https://github.com/theforeman/puppet-katello_devel/pull/245

This also requires https://github.com/theforeman/forklift/pull/1217 as the base CentOS 8 box is only 10GB and the devel install will run out of disk space before completing.