### PR TITLE
Set Pulpcore version to 3.7 where applicable

### DIFF
--- a/roles/pulpcore_repositories/defaults/main.yml
+++ b/roles/pulpcore_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-pulpcore_repositories_version: '3.6'
+pulpcore_repositories_version: '3.7'

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -90,7 +90,7 @@ installers:
   - foreman: '2.3'
     katello: '3.18'
     pulp: '2.21'
-    pulpcore: '3.6'
+    pulpcore: '3.7'
     puppet: 6
     boxes:
       - 'centos7'
@@ -102,7 +102,7 @@ installers:
   - foreman: 'nightly'
     katello: 'nightly'
     pulp: '2.21'
-    pulpcore: '3.6'
+    pulpcore: '3.7'
     puppet: 6
     boxes:
       - 'centos7'


### PR DESCRIPTION
For production installs the version is determined by katello-repos and that switched to 3.7. This mirrors it or 3.18 and nightly.