### PR TITLE
Publish first BATs CV 2nd time even if no puppet content

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -262,16 +262,12 @@ setup() {
     --content-view="${CONTENT_VIEW}" --id=$module_id | grep -q "Puppet module added to content view"
 }
 
-@test "publish content view with puppet content" {
-  tSkipIfNoPulp2 "Puppet content"
-
+@test "publish first content view again" {
   hammer content-view publish --organization="${ORGANIZATION}" \
     --name="${CONTENT_VIEW}"
 }
 
-@test "promote content view with puppet content" {
-  tSkipIfNoPulp2 "Puppet content"
-
+@test "promote first content view again" {
   hammer content-view version promote  --organization="${ORGANIZATION}" \
     --content-view="${CONTENT_VIEW}" --to-lifecycle-environment="${LIFECYCLE_ENVIRONMENT}" --from-lifecycle-environment="Library"
 }


### PR DESCRIPTION
The advanced content view tests that occur later rely on the first content view being published and promoted twice.  This causes failures if there is no puppet content type enabled or if Pulp 2 is not installed.  This PR causes the first content view to always be published and promoted a second time.