### PR TITLE
Identify content proxy by hardcoded ID

### DIFF
--- a/bats/fb-katello-proxy.bats
+++ b/bats/fb-katello-proxy.bats
@@ -9,9 +9,9 @@ load fixtures/content
 
 setup() {
   tSetOSVersion
-  PROXY_INFO=$(hammer --output json proxy list --search "feature = \"Pulp Node\"")
-  PROXY_ID=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read).first['Id']")
-  PROXY_HOSTNAME=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read).first['Name']")
+  PROXY_ID=2
+  PROXY_INFO=$(hammer --output json proxy show --id $PROXY_ID)
+  PROXY_HOSTNAME=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read)['Name']")
 }
 
 @test "proxy is registered" {


### PR DESCRIPTION
Will need:

 * https://github.com/Katello/katello/pull/9037
 * SELinux fixes
 * https://github.com/theforeman/puppet-foreman_proxy_content/pull/293
 * https://github.com/theforeman/foreman-installer/pull/611

I will update with PRs once they are available.