### PR TITLE
Client tests on smoker

### DIFF
--- a/bats/fb-katello-client.bats
+++ b/bats/fb-katello-client.bats
@@ -30,7 +30,7 @@ load fixtures/content
   run yum erase -y 'katello-ca-consumer-*'
   echo "rc=${status}"
   echo "${output}"
-  run rpm -Uvh http://localhost/pub/katello-ca-consumer-latest.noarch.rpm
+  run rpm -Uvh http://$REGISTRATION_HOSTNAME/pub/katello-ca-consumer-latest.noarch.rpm
   echo "rc=${status}"
   echo "${output}"
   subscription-manager register --force --org="${ORGANIZATION_LABEL}" --username=admin --password=changeme --env=Library

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -19,7 +19,9 @@ tForemanVersion() {
 }
 
 tIsPulp2() {
-  tPackageExists pulp-server
+  ping=$(hammer --output json ping)
+  has_pulp=$(echo $ping | ruby -e "require 'json'; puts JSON.load(ARGF.read)[0].key?('pulp')")
+  [ $has_pulp = true ]
 }
 
 tSkipIfNoPulp2() {

--- a/pipelines/install/07-client-tests.yaml
+++ b/pipelines/install/07-client-tests.yaml
@@ -1,0 +1,26 @@
+---
+- name: run client tests
+  become: true
+  hosts:
+    - "{{ forklift_smoker_name }}"
+  vars_files:
+    - ../vars/install_base.yml
+  vars:
+    hammer_credentials_username: admin
+    hammer_credentials_password: changeme
+    hammer_credentials_host: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
+    hammer_credentials_verify_ssl: false
+  environment:
+    REGISTRATION_HOSTNAME: "{{ forklift_server_name }}"
+  roles:
+    - role: etc_hosts
+      become: true
+    - role: epel_repositories
+      become: true
+    - role: foreman_repositories
+    - role: katello_repositories
+    - role: foreman_client_repositories
+    - role: hammer_credentials
+    - role: foreman_testing
+      bats_tests:
+        - "fb-katello-client.bats"

--- a/pipelines/install/08-finish.yaml
+++ b/pipelines/install/08-finish.yaml
@@ -1,0 +1,19 @@
+---
+- name: run tests
+  hosts:
+    - "{{ forklift_server_name }}"
+  become: true
+  vars_files:
+    - ../vars/install_base.yml
+    - ../vars/repos_staging.yml
+  environment:
+    FOREMAN_EXPECTED_VERSION: "{{ foreman_expected_version | default('') }}"
+  roles:
+    - role: forklift_versions
+      scenario: "{{ pipeline_type }}"
+      scenario_os: "{{ pipeline_os }}"
+      scenario_version: "{{ pipeline_version }}"
+    - role: foreman_testing
+      bats_tests:
+        - "fb-destroy-organization.bats"
+        - "fb-finish.bats"

--- a/pipelines/install_pipeline.yml
+++ b/pipelines/install_pipeline.yml
@@ -5,3 +5,5 @@
 - import_playbook: install/04-install_proxy.yaml
 - import_playbook: install/05-tests.yaml
 - import_playbook: install/06-smoker.yaml
+- import_playbook: install/07-client-tests.yaml
+- import_playbook: install/08-finish.yaml

--- a/pipelines/vars/install_base.yml
+++ b/pipelines/vars/install_base.yml
@@ -1,7 +1,7 @@
-forklift_name: "pipeline-{{ pipeline_type }}-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_server_name: "pipeline-{{ pipeline_type }}-server-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_proxy_name: "pipeline-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_smoker_name: "pipeline-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_name: "pipe-{{ pipeline_type }}-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_server_name: "pipe-{{ pipeline_type }}-server-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_proxy_name: "pipe-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_smoker_name: "pipe-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 smoker_box:
   box: centos7
   memory: 2048

--- a/roles/bats/defaults/main.yaml
+++ b/roles/bats/defaults/main.yaml
@@ -3,8 +3,8 @@ bats_fetch_results: true
 bats_environment: {}
 bats_git_dir: "/root/bats"
 bats_forklift_dir: "/root/forklift"
-bats_forklift_repo: "https://github.com/theforeman/forklift.git"
-bats_forklift_version: HEAD
+bats_forklift_repo: "https://github.com/ehelms/forklift.git"
+bats_forklift_version: client-tests-on-smoker
 bats_output_dir: "/root/bats_results"
 bats_remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
 bats_update_forklift: "yes"
@@ -16,8 +16,5 @@ bats_tests:
   - "fb-test-puppet.bats"
   - "fb-test-katello.bats"
   - "fb-katello-content.bats"
-  - "fb-katello-client.bats"
 bats_tests_additional: []
-bats_teardown:
-  - "fb-destroy-organization.bats"
-  - "fb-finish.bats"
+bats_teardown: []

--- a/roles/hammer_credentials/tasks/main.yml
+++ b/roles/hammer_credentials/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install hammer
+  package:
+    name: tfm-rubygem-hammer_cli_katello
+
 - name: 'Add hammer config directory'
   file:
     path: ~/.hammer


### PR DESCRIPTION
I am only currently applying this change to the install pipeline for feedback. The idea here is to move the client testing bats tests to run on the smoker box. Thereby creating an isolated client from which to test. This requires changes to the client bats tests that are reflected here. After this change, I am planning to explore running these bats tests each from a container running on the smoker box, one for each OS we care about testing.