### PR TITLE
don't enable qpid copr on 3.18 releases

### DIFF
--- a/roles/katello_repositories/tasks/main.yml
+++ b/roles/katello_repositories/tasks/main.yml
@@ -11,4 +11,4 @@
 - include_tasks: qpid.yml
   when:
     - ansible_distribution_major_version == "7"
-    - katello_repositories_environment == "staging" or (katello_repositories_version != "nightly" and katello_repositories_version is version('3.18', '<='))
+    - katello_repositories_environment == "staging" or (katello_repositories_version != "nightly" and katello_repositories_version is version('3.17', '<='))


### PR DESCRIPTION
3.18 has a fixed katello-repos now