### PR TITLE
Drop EOL CentOS 6 box

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -1,14 +1,4 @@
 boxes:
-  centos6:
-    box_name:   'centos/6'
-    image_name: !ruby/regexp '/CentOS 6.*PV/'
-    google_options:
-      image_family: 'centos-6'
-    pty:        true
-    scenarios:
-      - foreman
-      - katello
-
   centos7:
     box_name:   'centos/7'
     image_name: !ruby/regexp '/CentOS 7.*PV/'


### PR DESCRIPTION
The image has been removed from the Vagrant Cloud so this can no longer be installed. Even if users have a local image available, the mirror network has also dropped all packages so it would be useless.