### PR TITLE
Update testing.md for Bats local development

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ This section covers test infrastructure and environments that can be spun up usi
  * [Bats Testing](#bats-testing)
  * [Running Robottelo Tests](#running-robottelo-tests)
 
-## Bats Testing
+# Bats Testing
 
 Included with forklift is a small live test suite.  The current tests are:
 
@@ -16,18 +16,14 @@ Included with forklift is a small live test suite.  The current tests are:
   * fb-destroy-organization.bats - Cleans up after the content tests
   * fb-finish.bats - Collects logs pertinent to the bats run
 
-To execute the bats framework:
+### To run the same setup run by CI system
 
- * Using vagrant (after configuring vagrant according to this document):
+```
+cp boxes.yaml.example boxes.yaml
+vagrant up centos7-katello-bats-ci
+```
 
-    vagrant up centos7-pipeline-bats
-
-To run the same setup run by CI system:
-
-    cp boxes.yaml.example boxes.yaml
-    vagrant up centos7-bats-ci
-
-If you are making changes to bats tests and want to test your updates, edit `centos7-bats-ci` to include:
+If you are making changes to bats tests and want to test your updates, edit `centos7-katello-bats-ci` to include:
 
     ansible:
       ....
@@ -35,7 +31,7 @@ If you are making changes to bats tests and want to test your updates, edit `cen
         bats_forklift_dir: /vagrant
         bats_update_forklift: "no"
 
-Or if you want to run bats from a different repository or branch, edit `centos7-bats-ci` to include:
+Or if you want to run bats from a different repository or branch, edit `centos7-katello-bats-ci` to include:
 
     ansible:
       ....
@@ -43,7 +39,22 @@ Or if you want to run bats from a different repository or branch, edit `centos7-
         bats_forklift_repo: https://github.com/<YOUR_NAME>/forklift.git
         bats_forklift_version: your-branch
 
-## Pipeline Testing
+### To run Bats on an existing VM for development
+
+1. Install `bats`: `yum install bats` or `apt install bats`
+2. Make sure your Foreman server is running
+3. If your tests use Hammer, make sure you have a working `hammer` command
+4. `cd` to your `forklift` directory
+5. Run bats by specifying the test filename(s):
+
+```
+bats bats/fb-katello-content.bats
+```
+
+_Note_: Bats tests are not idempotent, so you may have to do some cleanup or skip some tests when running bats multiple times.
+
+
+# Pipeline Testing
 
 Under `pipelines` are a series of playbooks designed around testing scenarios for various version of the Foreman and Katello stack. To run one:
 
@@ -53,7 +64,7 @@ When you are finished with the test, you can tear down the associated infrastruc
 
     ansible-playbook pipelines/<pipeline>.yml -e forklift_state=destroy -e <vars required by pipeline>
 
-### Existing Pipelines
+## Existing Pipelines
 
 * `install_pipeline` - Installs a Server and a Proxy VMs and runs the `foreman_testing` role to verify the setup.
   Expects the `pipeline_os` variable to be set to a known OS (currently: centos7, debian10)
@@ -69,7 +80,7 @@ When you are finished with the test, you can tear down the associated infrastruc
     ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=debian10 -e pipeline_type=foreman -e pipeline_version=nightly
     ansible-playbook pipelines/upgrade_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
 
-### Creating Pipelines
+## Creating Pipelines
 
 If you wish to add a new version of an existing pipeline (e.g. a new Katello release), you only have to add the corresponding vars files to `pipelines/vars/`.
 
@@ -98,9 +109,9 @@ katello_version_intermediate: '3.10'
 katello_version_final: '{{ katello_version }}'
 ```
 
-## Running Robottelo Tests
+# Running Robottelo Tests
 
-Robottelo is a test suite for excercising Foreman and Katello. Forklift provides a role for Robottelo to set up and run tests against your machine. Configuration options of interest are `robottelo_test_endpoints` where you can pass a list of endpoints (api, cli or ui), and `robottelo_test_type`, which is one of:
+Robottelo is a test suite for exercising Foreman and Katello. Forklift provides a role for Robottelo to set up and run tests against your machine. Configuration options of interest are `robottelo_test_endpoints` where you can pass a list of endpoints (api, cli or ui), and `robottelo_test_type`, which is one of:
 
 - tier1 to tier4 - base test sets, tier1 tests can resemble unit testing, higher tiers require more extensive setup
 - destructive - tests that restart or rename the server


### PR DESCRIPTION
I was about to add some Bats tests but paused work in light of https://github.com/theforeman/smoker/pull/11.

Not sure if this documentation update will still be useful, but opening this PR for feedback.

* Update testing.md with instructions to run Bats on a foreman devel box.  (These steps are what I had to do to get it running)
* correct filename of `fb-katello-content.bats` in `bats/katello-bats`.  Looks like this was not noticed before because `bats/katello-bats` isn't run by the Ansible roles that run Bats.