### PR TITLE
Do not run Puppet tests if Pulp 3 only for Katello 4

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -74,14 +74,14 @@ setup() {
 }
 
 @test "create puppet repository" {
-  tSkipIfNoPulp2 "Puppet content"
+  tSkipIfPulp3Only "Puppet content"
 
   hammer repository create --organization="${ORGANIZATION}" \
     --product="${PRODUCT}" --content-type="puppet" --name "${PUPPET_REPOSITORY}" | grep -q "Repository created"
 }
 
 @test "upload puppet module" {
-  tSkipIfNoPulp2 "Puppet content"
+  tSkipIfPulp3Only "Puppet content"
 
   curl -o /tmp/stbenjam-dummy-0.2.0.tar.gz https://forgeapi.puppetlabs.com/v3/files/stbenjam-dummy-0.2.0.tar.gz
   tFileExists /tmp/stbenjam-dummy-0.2.0.tar.gz && hammer repository upload-content \
@@ -138,7 +138,7 @@ setup() {
 }
 
 @test "add puppet module to content view" {
-  tSkipIfNoPulp2 "Puppet content"
+  tSkipIfPulp3Only "Puppet content"
 
   repo_id=$(hammer --csv --no-headers repository list --organization="${ORGANIZATION}" \
     | grep Puppet | cut -d, -f1)

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -18,13 +18,30 @@ tForemanVersion() {
   ) | cut -d. -f1-2
 }
 
+tKatelloVersion() {
+  (
+    if tPackageExists tfm-rubygem-katello; then
+      tPackageVersion tfm-rubygem-katello
+    elif tPackageExists rubygem-katello; then
+      tPackageVersion rubygem-katello
+    fi
+  ) | cut -d. -f1-2
+}
+
+tSkipIfPulp3Only() {
+  KATELLO_VERSION=$(tKatelloVersion)
+  if [[ $KATELLO_VERSION == 4.* ]]; then
+    skip "${1} is not available in scenarios with only Pulp 3"
+  fi
+}
+
 tIsPulp2() {
   tPackageExists pulp-server
 }
 
 tSkipIfNoPulp2() {
   if ! tIsPulp2; then
-   skip "${1} is not available in scenarios without Pulp 2"
+    skip "${1} is not available in scenarios without Pulp 2"
   fi
 }
 
@@ -38,7 +55,7 @@ tSkipIfHammerBelow018() {
 
   run rpmdev-vercmp $RPM_VERSION 0.18 > /dev/null
   if [[ $status == 12 ]]; then
-   skip "Advanced content view tests are not available without hammer-cli >= 0.18"
+    skip "Advanced content view tests are not available without hammer-cli >= 0.18"
   fi
 }
 


### PR DESCRIPTION
We have a period of time where Pulp 2 is around for katello-agent support but not content so we need to skip Puppet tests based n Katello version and not the presence of Pulp 2.