### PR TITLE
Shorten pipeline hostnames due to reverse proxy size limits

### DIFF
--- a/pipelines/vars/install_base.yml
+++ b/pipelines/vars/install_base.yml
@@ -1,7 +1,7 @@
-forklift_name: "pipeline-{{ pipeline_type }}-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_server_name: "pipeline-{{ pipeline_type }}-server-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_proxy_name: "pipeline-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ pipeline_os }}"
-forklift_smoker_name: "pipeline-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_name: "pipe-{{ pipeline_type }}-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_server_name: "pipe-{{ pipeline_type }}-server-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_proxy_name: "pipe-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_smoker_name: "pipe-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 smoker_box:
   box: centos7
   memory: 2048

--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -1,7 +1,7 @@
-forklift_name: "pipeline-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_server_name: "pipeline-up-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_proxy_name: "pipeline-up-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
-forklift_smoker_name: "pipeline-up-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_name: "pipe-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_server_name: "pipe-up-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_proxy_name: "pipe-up-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"
+forklift_smoker_name: "pipe-up-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 forklift_boxes: "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"
 smoker_box:
   box: centos7


### PR DESCRIPTION
I hit this in about all of my environments, so throwing it out there in hopes to get it accepted so I can stop accidentally committing this change with every PR I open.