### PR TITLE
Add common pipeline variable combinations

### DIFF
--- a/pipelines/vars/common/foreman_nightly_centos7.yml
+++ b/pipelines/vars/common/foreman_nightly_centos7.yml
@@ -1,0 +1,4 @@
+---
+pipeline_type: foreman
+pipeline_os: centos7
+pipeline_version: nightly

--- a/pipelines/vars/common/foreman_nightly_centos8.yml
+++ b/pipelines/vars/common/foreman_nightly_centos8.yml
@@ -1,0 +1,4 @@
+---
+pipeline_type: foreman
+pipeline_os: centos8
+pipeline_version: nightly

--- a/pipelines/vars/common/katello_nightly_centos7.yml
+++ b/pipelines/vars/common/katello_nightly_centos7.yml
@@ -1,0 +1,4 @@
+---
+pipeline_type: katello
+pipeline_os: centos7
+pipeline_version: nightly

--- a/pipelines/vars/common/katello_nightly_centos8.yml
+++ b/pipelines/vars/common/katello_nightly_centos8.yml
@@ -1,0 +1,4 @@
+---
+pipeline_type: katello
+pipeline_os: centos8
+pipeline_version: nightly


### PR DESCRIPTION
I often find myself running these combinations and storing those locally when running pipelines.

```
ansible-playbook pipelines/install_pipeline.yml -e @pipelines/vars/common/katello_nightly_centos7.yml
```