### PR TITLE
use proxy info instead of proxy show

### DIFF
--- a/bats/fb-katello-proxy.bats
+++ b/bats/fb-katello-proxy.bats
@@ -10,7 +10,7 @@ load fixtures/content
 setup() {
   tSetOSVersion
   PROXY_ID=2
-  PROXY_INFO=$(hammer --output json proxy show --id $PROXY_ID)
+  PROXY_INFO=$(hammer --output json proxy info --id $PROXY_ID)
   PROXY_HOSTNAME=$(echo $PROXY_INFO | ruby -e "require 'json'; puts JSON.load(ARGF.read)['Name']")
 }
 


### PR DESCRIPTION
proxy show seems to work on Foreman 2.1+, but not on 1.24 and older.
proxy info yields the same output, and works everywhere.

this was originally introduced in c2adb0daa031eef6dce089a2be720ed49283cfa8