### PR TITLE
Return early if there are no hosts

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -93,6 +93,9 @@ def get_variables(hosts):
 
 
 def get_configs(hosts):
+    if not hosts:
+        return
+
     ssh_configs = get_ssh_configs(hosts)
     variables = get_variables(hosts)
 


### PR DESCRIPTION
If no hosts are specified, there are also no configs. This situation can occur when calling it with `--list`. `list_running_hosts` is called and `get_running_hosts` returns an empty list. Then `get_configs([])` is called.

Prior to this patch, it would call vagrant ssh-config without arguments. This can be slow and expensive. It would still list all configs, also for unrelated machines. Now the entire call is avoided, giving a nice speed boost.