### PR TITLE
Fix warning about string conversions

### DIFF
--- a/playbooks/kubevirt.yml
+++ b/playbooks/kubevirt.yml
@@ -63,9 +63,9 @@
         name: kubernetes
         description: Kubernetes
         baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-        enabled: true
-        gpgcheck: true
-        repo_gpgcheck: true
+        enabled: yes
+        gpgcheck: yes
+        repo_gpgcheck: yes
         gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
         exclude: kube*
 

--- a/roles/foreman_client_repositories/tasks/staging_repo.yml
+++ b/roles/foreman_client_repositories/tasks/staging_repo.yml
@@ -11,5 +11,5 @@
     name: foreman-client-koji
     description: "Foreman {{ foreman_client_repositories_version }} Client Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-client-{{ foreman_client_repositories_version }}/{{ foreman_client_repositories_dists[ansible_os_family] }}{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: '1'
+    gpgcheck: no

--- a/roles/foreman_repositories/tasks/redhat_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_staging_repos.yml
@@ -18,7 +18,7 @@
     description: "Foreman {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-{{ foreman_repositories_version }}/RHEL/{{ ansible_distribution_major_version }}/x86_64/"
     priority: "1"
-    gpgcheck: "0"
+    gpgcheck: no
     include: /etc/yum/foreman.conf
   tags:
     - packages
@@ -30,7 +30,7 @@
     description: "Foreman Plugins {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-plugins-{{ foreman_repositories_version }}/RHEL/{{ ansible_distribution_major_version }}/x86_64/"
     priority: "1"
-    gpgcheck: "0"
+    gpgcheck: no
     include: /etc/yum/foreman.conf
   tags:
     - packages

--- a/roles/katello_client_repositories/tasks/main.yml
+++ b/roles/katello_client_repositories/tasks/main.yml
@@ -4,8 +4,8 @@
     name: katello-client-koji
     description: "Katello {{ katello_client_repositories_version }} Client Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_client_repositories_version }}/client/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: '1'
+    gpgcheck: no
   when: katello_client_repositories_environment == "staging"
 
 - name: 'Setup Katello {{ katello_client_repositories_version }} Client Release Repository'

--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -9,8 +9,8 @@
     name: katello-koji
     description: "Katello {{ katello_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: '1'
+    gpgcheck: no
     include: /etc/yum/foreman.conf
 
 - name: 'Candlepin Koji repository'
@@ -18,8 +18,8 @@
     name: candlepin-koji
     description: "Candlepin {{ katello_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/candlepin/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: 1
-    gpgcheck: 0
+    priority: '1'
+    gpgcheck: no
     include: /etc/yum/foreman.conf
 
 - name: 'Add Pulp {{ katello_repositories_pulp_version }} Stable repository'

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -12,7 +12,7 @@
   become: true
   sysctl:
     name: user.max_user_namespaces
-    value: 100000
+    value: '100000'
 
 - name: Set subuid range for user
   become: true

--- a/roles/powerdns/tasks/main.yml
+++ b/roles/powerdns/tasks/main.yml
@@ -5,8 +5,8 @@
     description: "PowerDNS repository for PowerDNS Authoritative Server - version 4.0.X"
     baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-40"
     gpgkey: "https://repo.powerdns.com/FD380FBB-pub.asc"
-    gpgcheck: "1"
-    enabled: "1"
+    gpgcheck: yes
+    enabled: yes
 
 - name: "Install PowerDNS"
   package:

--- a/roles/pulp_repositories/tasks/main.yml
+++ b/roles/pulp_repositories/tasks/main.yml
@@ -24,5 +24,5 @@
     name: jortel-gofer
     description: Copr repo for gofer owned by jortel
     baseurl: "https://copr-be.cloud.fedoraproject.org/results/jortel/gofer/epel-{{ ansible_distribution_major_version }}-x86_64/"
-    gpgcheck: 1
+    gpgcheck: yes
     gpgkey: https://copr-be.cloud.fedoraproject.org/results/jortel/gofer/pubkey.gpg


### PR DESCRIPTION
This fixes the following warning with sysctl:

    [WARNING]: The value 100000 (type int) in a string field was converted to u'100000' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

This fixes the following warning with yum_repository:

    [WARNING]: The value 1 (type int) in a string field was converted to u'1' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

Note that the type should be a string, but then the documentation states it should be an integer from 1 to 99.

There was no warning about gpgcheck, but this follows valid values according to the documentation. It's also used elsewhere in the same file so it makes it more consistent.