### PR TITLE
Install the latest Vagrant version (2.2.14)

### DIFF
--- a/roles/vagrant/defaults/main.yml
+++ b/roles/vagrant/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 vagrant_libvirt: true
-vagrant_version: 2.2.7
+vagrant_version: 2.2.14
 vagrant_scp: true


### PR DESCRIPTION
Our current nightly pipelines are failing because nokogiri needs Ruby >= 2.5 and perhaps this bundles a newer Ruby, but I honestly doubt it. However, it doesn't hurt to at least install the latest version.