### PR TITLE
use ansible_nodename of the server as smoker_url

### DIFF
--- a/pipelines/install/06-smoker.yaml
+++ b/pipelines/install/06-smoker.yaml
@@ -5,7 +5,7 @@
   vars_files:
     - ../vars/install_base.yml
   vars:
-    smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
+    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_nodename }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   roles:

--- a/pipelines/upgrade/10-smoker.yaml
+++ b/pipelines/upgrade/10-smoker.yaml
@@ -5,7 +5,7 @@
   vars_files:
     - ../vars/upgrade_base.yml
   vars:
-    smoker_base_url: "https://{{ forklift_server_name }}.{{ ansible_domain }}"
+    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_nodename }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   roles:


### PR DESCRIPTION
the inventory name does not match the hostname for non-nightly boxes
which have a version with dots in their inventory name

Fixes: #1211