### PR TITLE
Use pytest-xdist in smoker to launch 2 processes

### DIFF
--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -5,7 +5,7 @@ smoker_directory: "{{ ansible_env.HOME }}/smoker"
 smoker_variables: {}
 smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
-smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv"
+smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
 smoker_markers:
 smoker_browser_packages:
   - chromium


### PR DESCRIPTION
In my experience, there is a speedup if you use multiple processes since there are times you wait. The number 2 was chosen because a large number of our tests runs a browser and that can take a bit of memory. Even on my laptop I saw diminishing returns after a while. 2 is a fairly conservative number, but can already help.