### PR TITLE
Revert "Use pytest-xdist in smoker to launch 2 processes"

### DIFF
--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -5,7 +5,7 @@ smoker_directory: "{{ ansible_env.HOME }}/smoker"
 smoker_variables: {}
 smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
-smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
+smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv"
 smoker_markers:
 smoker_browser_packages:
   - chromium


### PR DESCRIPTION
Reverts theforeman/forklift#1265

This made things worse and CI now takes 4h for smoker, instead of 1.