### PR TITLE
explicitly look for junit.xml in the smoker output

### DIFF
--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -24,7 +24,7 @@
       find:
         paths: "{{ smoker_output_dir }}"
         patterns:
-          - "*.xml"
+          - "junit.xml"
           - "*.html"
           - "*.css"
           - "*.png"


### PR DESCRIPTION
there might be other xml files, we don't want them