### PR TITLE
disable gpg checking in pulp_installer for pipelines

### DIFF
--- a/pipelines/vars/forklift_pulpcore.yml
+++ b/pipelines/vars/forklift_pulpcore.yml
@@ -7,6 +7,7 @@ forklift_boxes:
 
 pulp_install_source: packages
 pulp_pkg_repo: "http://koji.katello.org/releases/yum/pulpcore-{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo_gpgcheck: False
 pulp_settings:
   secret_key: "unsafe_default"
   content_origin: "http://{{ ansible_fqdn }}"


### PR DESCRIPTION
pipelines use koji staging repos, which don't have the GPG key