### PR TITLE
install python3-policycoreutils for pulpcore on el8

### DIFF
--- a/pipelines/pulpcore/02-install.yaml
+++ b/pipelines/pulpcore/02-install.yaml
@@ -8,6 +8,14 @@
     - ../vars/forklift_{{ pipeline_type }}.yml
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+  pre_tasks:
+    - name: install python3-policycoreutils
+      package:
+        name: python3-policycoreutils
+        state: present
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version == '8'
   roles:
     - epel_repositories
     - pulp.pulp_installer.pulp_all_services


### PR DESCRIPTION
pulp_installer uses the seport module, but doesn't install all of its
prerequisites, workaround that for now!

Real fix is in https://github.com/pulp/pulp_installer/pull/513/