### PR TITLE
Revert "install python3-policycoreutils for pulpcore on el8"

### DIFF
--- a/pipelines/pulpcore/02-install.yaml
+++ b/pipelines/pulpcore/02-install.yaml
@@ -8,14 +8,6 @@
     - ../vars/forklift_{{ pipeline_type }}.yml
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
-  pre_tasks:
-    - name: install python3-policycoreutils
-      package:
-        name: python3-policycoreutils
-        state: present
-      when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '8'
   roles:
     - epel_repositories
     - pulp.pulp_installer.pulp_all_services


### PR DESCRIPTION
This reverts commit f3543101cd933dddc13c900ef8422f0ed4779708.

An updated pulp_installer is available on galaxy