### PR TITLE
Fix bug in swapfile role

### DIFF
--- a/roles/swapfile/tasks/main.yml
+++ b/roles/swapfile/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: "activate {{ swapfile_path }}"
   command: "swapon {{ swapfile_path }}"
-  when: swapfile_active | failed
+  when: swapfile_active is failed
 
 - name: set vm.swappiness to 60
   sysctl:


### PR DESCRIPTION
This fixes a bug that occurs when running bats tests:

```
TASK [activate /swapfile] ******************************************************
fatal: [centos7-katello-bats-ci]: FAILED! => 
  msg: |-
    The conditional check 'swapfile_active | failed' failed. The error was: template error while templating string: no filter named 'failed'. String: {% if swapfile_active | failed %} True {% else %} False {% endif %}
```