### PR TITLE
pin chromium to 86.x which works fine -- local RPM copy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        run: pip install 'ansible-lint<5.0'
       - name: Run tests
         run: |
           ansible-lint -r rules/ playbooks/*

--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -7,8 +7,6 @@ smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
 smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
 smoker_markers:
-# pinned to 86 as 87 hangs randomly: https://bugzilla.redhat.com/show_bug.cgi?id=1914166
 smoker_browser_packages:
-  - https://kojipkgs.fedoraproject.org//packages/chromium/86.0.4240.193/1.el7/x86_64/chromedriver-86.0.4240.193-1.el7.x86_64.rpm
-  - https://kojipkgs.fedoraproject.org//packages/chromium/86.0.4240.193/1.el7/x86_64/chromium-86.0.4240.193-1.el7.x86_64.rpm
-  - https://kojipkgs.fedoraproject.org//packages/chromium/86.0.4240.193/1.el7/x86_64/chromium-common-86.0.4240.193-1.el7.x86_64.rpm
+  - chromium
+  - chromedriver

--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -7,6 +7,8 @@ smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
 smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
 smoker_markers:
+# pinned to 86 as 87 hangs randomly: https://bugzilla.redhat.com/show_bug.cgi?id=1914166
 smoker_browser_packages:
-  - chromium
-  - chromedriver
+  - https://people.redhat.com/evgeni/chrome86/chromedriver-86.0.4240.193-1.el7.x86_64.rpm
+  - https://people.redhat.com/evgeni/chrome86/chromium-86.0.4240.193-1.el7.x86_64.rpm
+  - https://people.redhat.com/evgeni/chrome86/chromium-common-86.0.4240.193-1.el7.x86_64.rpm


### PR DESCRIPTION
These builds have been removed from Koji, so we can't install them
anymore from there. Point to a local copy of the RPMs.