### PR TITLE
Remove enable pki-core workaround

### DIFF
--- a/roles/katello_repositories/tasks/main.yml
+++ b/roles/katello_repositories/tasks/main.yml
@@ -2,12 +2,6 @@
 - name: "Set up {{ katello_repositories_environment }} repositories"
   include_tasks: "{{ katello_repositories_environment }}_repos.yml"
 
-- name: enable pki-core module
-  command: dnf module -y enable pki-core
-  when: ansible_distribution_major_version == "8"
-  args:
-    warn: false # dnf module can't handle modules
-
 - name: enable powertools for libdb_cxx used by qpid-cpp-server-linearstore
   command: dnf config-manager --set-enabled powertools
   when: ansible_distribution_major_version == "8"


### PR DESCRIPTION
The installer started to take care of this. It can be removed safely because there has been no Katello release on EL8 and is only needed for Candlepin.