### PR TITLE
Use foreman-installer-katello instead of meta packages

### DIFF
--- a/pipelines/pipeline_katello_lbproxy.yml
+++ b/pipelines/pipeline_katello_lbproxy.yml
@@ -61,7 +61,7 @@
       - "--enable-foreman-plugin-remote-execution"
       - "--enable-foreman-proxy-plugin-remote-execution-ssh"
     foreman_installer_additional_packages:
-      - katello
+      - foreman-installer-katello
   roles:
     - foreman_installer
   tasks:

--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -8,7 +8,7 @@ server_box:
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: katello
       foreman_installer_additional_packages:
-        - katello
+        - foreman-installer-katello
       foreman_installer_options:
         - "--puppet-server-max-active-instances 1"
         - "--puppet-server-jvm-min-heap-size 1G"
@@ -25,6 +25,6 @@ proxy_box:
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: foreman-proxy-content
       foreman_installer_additional_packages:
-        - foreman-proxy-content
+        - foreman-installer-katello
 forklift_boxes:
   "{{ {forklift_server_name: server_box, forklift_proxy_name: proxy_box, forklift_smoker_name: smoker_box} }}"

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -8,7 +8,7 @@ server_box:
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: katello
       foreman_installer_additional_packages:
-        - katello
+        - foreman-installer-katello
       foreman_installer_options:
         - "--puppet-server-max-active-instances 1"
         - "--puppet-server-jvm-min-heap-size 1G"
@@ -44,7 +44,7 @@ proxy_box:
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: foreman-proxy-content
       foreman_installer_additional_packages:
-        - foreman-proxy-content
+        - foreman-installer-katello
       foreman_installer_options:
         - "--enable-foreman-proxy-plugin-ansible"
         - "--enable-foreman-proxy-plugin-discovery"

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -8,7 +8,7 @@
     puppet_repositories_version: 5
     foreman_installer_scenario: katello
     foreman_installer_additional_packages:
-      - katello
+      - foreman-installer-katello
     foreman_installer_disable_system_checks: true
     foreman_installer_options_internal_use_only:
       - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"

--- a/playbooks/foreman_proxy_content.yml
+++ b/playbooks/foreman_proxy_content.yml
@@ -26,4 +26,4 @@
         - "{{ '' if (foreman_repositories_version == 'nightly' or 2.3 is version(foreman_repositories_version, '>')) else ('--foreman-proxy-content-parent-fqdn %s' % server_fqdn) }}"
         - '--puppet-server-foreman-url https://"{{ server_fqdn }}"'
       foreman_installer_additional_packages:
-          - foreman-proxy-content
+          - foreman-installer-katello

--- a/playbooks/luna_demo_environment.yml
+++ b/playbooks/luna_demo_environment.yml
@@ -33,7 +33,7 @@
       - "--disable-system-checks"
     foreman_installer_additional_packages:
       - rubygem-ruby-libvirt
-      - katello
+      - foreman-installer-katello
     foreman_installer_options:
       - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
       - "--foreman-initial-organization {{ katello_provisioning_organization }}"

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -6,4 +6,4 @@ dependencies:
     foreman_installer_scenario: katello
     foreman_installer_disable_system_checks: true
     foreman_installer_additional_packages:
-      - katello
+      - foreman-installer-katello


### PR DESCRIPTION
This stops installing katello/foreman-proxy-content meta packages. The reason is that on EL8 you need to enable the pki-core module. In 517d8ddcb77f6fb97525cb4efd35db5212c301fb this was removed with the expectation that the installer takes care of it. This makes the katello meta-package uninstallable.

puppet-katello already ensures the katello meta package is installed. For foreman-proxy-content this isn't done so an installer change is needed if this package is actually needed.