### PR TITLE
forklift_versions: allow specifying an offset to get an older version

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,35 +82,6 @@ When you are finished with the test, you can tear down the associated infrastruc
     ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=nightly -e pipeline_proxy_delay=1
     ansible-playbook pipelines/upgrade_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
 
-## Creating Pipelines
-
-If you wish to add a new version of an existing pipeline (e.g. a new Katello release), you only have to add the corresponding vars files to `pipelines/vars/`.
-
-For Katello 3.11, you'd be adding the following two files:
-
-`pipelines/vars/katello_3.11.yml`:
-```yaml
-forklift_name: pipeline-katello-3.11
-forklift_boxes:
-  pipeline-katello-3.11-centos7:
-    box: centos7
-    memory: 8192
-  pipeline-proxy-3.11-centos7:
-    box: centos7
-    memory: 3072
-katello_repositories_version: '3.11'
-katello_repositories_pulp_version: '2.19'
-foreman_repositories_version: '1.21'
-foreman_client_repositories_version: "{{ foreman_repositories_version }}"
-```
-
-`pipelines/vars/katello_upgrade_3.11.yml`:
-```yaml
-katello_version_start: '3.9'
-katello_version_intermediate: '3.10'
-katello_version_final: '{{ katello_version }}'
-```
-
 # Running Robottelo Tests
 
 Robottelo is a test suite for exercising Foreman and Katello. Forklift provides a role for Robottelo to set up and run tests against your machine. Configuration options of interest are `robottelo_test_endpoints` where you can pass a list of endpoints (api, cli or ui), and `robottelo_test_type`, which is one of:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,6 +70,7 @@ When you are finished with the test, you can tear down the associated infrastruc
   Expects the `pipeline_os` variable to be set to a known OS (currently: centos7, debian10)
   Expects the `pipeline_type` variable to be set to a known type (currently: foreman, katello, luna)
   Expects the `pipeline_version` variable to be set to a known version (currently: 3.8, 3.9, 3.10, 3.11, nightly)
+  Accepts the `pipeline_proxy_delay` variable to install the Proxy with an older version than the Server (default: `0`)
 * `upgrade_pipeline` - Installs a VM, upgrades it twice and runs the `foreman_testing` role to verify the final upgrade.
   Expects the `pipeline_os` variable to be set to a known OS (currently: centos7, debian10)
   Expects the `pipeline_type` variable to be set to a known type (currently: foreman, katello, luna)
@@ -78,6 +79,7 @@ When you are finished with the test, you can tear down the associated infrastruc
 #### Examples
 
     ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=debian10 -e pipeline_type=foreman -e pipeline_version=nightly
+    ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=nightly -e pipeline_proxy_delay=1
     ansible-playbook pipelines/upgrade_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
 
 ## Creating Pipelines

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,7 +70,7 @@ When you are finished with the test, you can tear down the associated infrastruc
   Expects the `pipeline_os` variable to be set to a known OS (currently: centos7, debian10)
   Expects the `pipeline_type` variable to be set to a known type (currently: foreman, katello, luna)
   Expects the `pipeline_version` variable to be set to a known version (currently: 3.8, 3.9, 3.10, 3.11, nightly)
-  Accepts the `pipeline_proxy_delay` variable to install the Proxy with an older version than the Server (default: `0`)
+  Accepts the `pipeline_proxy_version_offset` variable to install the Proxy with an older version than the Server (default: `0`)
 * `upgrade_pipeline` - Installs a VM, upgrades it twice and runs the `foreman_testing` role to verify the final upgrade.
   Expects the `pipeline_os` variable to be set to a known OS (currently: centos7, debian10)
   Expects the `pipeline_type` variable to be set to a known type (currently: foreman, katello, luna)
@@ -79,7 +79,7 @@ When you are finished with the test, you can tear down the associated infrastruc
 #### Examples
 
     ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=debian10 -e pipeline_type=foreman -e pipeline_version=nightly
-    ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=nightly -e pipeline_proxy_delay=1
+    ansible-playbook pipelines/install_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=nightly -e pipeline_proxy_version_offset=1
     ansible-playbook pipelines/upgrade_pipeline.yml -e forklift_state=up -e pipeline_os=centos7 -e pipeline_type=katello -e pipeline_version=3.10
 
 # Running Robottelo Tests

--- a/pipelines/install/02-setup.yaml
+++ b/pipelines/install/02-setup.yaml
@@ -1,5 +1,48 @@
 ---
-- name: prepare boxes, update os, configure repos, configure os
+- name: prepare boxes, update os, configure os
+  hosts:
+    - "{{ forklift_server_name }}"
+    - "{{ forklift_proxy_name }}"
+  become: yes
+  vars_files:
+    - ../vars/install_base.yml
+    - ../vars/repos_staging.yml
+  roles:
+    - role: vagrant_workarounds
+    - role: enable_ipv6
+    - role: disable_firewall
+    - role: update_os_packages
+
+- name: configure repos on server
+  hosts:
+    - "{{ forklift_server_name }}"
+  become: yes
+  vars_files:
+    - ../vars/install_base.yml
+    - ../vars/repos_staging.yml
+  roles:
+    - role: forklift_versions
+      scenario: "{{ pipeline_type }}"
+      scenario_os: "{{ pipeline_os }}"
+      scenario_version: "{{ pipeline_version }}"
+    - role: foreman_server_repositories
+
+- name: configure repos on proxy
+  hosts:
+    - "{{ forklift_proxy_name }}"
+  become: yes
+  vars_files:
+    - ../vars/install_base.yml
+    - ../vars/repos_staging.yml
+  roles:
+    - role: forklift_versions
+      scenario: "{{ pipeline_type }}"
+      scenario_os: "{{ pipeline_os }}"
+      scenario_version: "{{ pipeline_version }}"
+      scenario_delay: "{{ pipeline_proxy_delay | default(0) }}"
+    - role: foreman_server_repositories
+
+- name: install packages
   hosts:
     - "{{ forklift_server_name }}"
     - "{{ forklift_proxy_name }}"
@@ -10,13 +53,4 @@
     - ../vars/install_base.yml
     - ../vars/repos_staging.yml
   roles:
-    - role: vagrant_workarounds
-    - role: forklift_versions
-      scenario: "{{ pipeline_type }}"
-      scenario_os: "{{ pipeline_os }}"
-      scenario_version: "{{ pipeline_version }}"
-    - role: enable_ipv6
-    - role: disable_firewall
-    - role: foreman_server_repositories
-    - role: update_os_packages
     - role: foreman

--- a/pipelines/install/02-setup.yaml
+++ b/pipelines/install/02-setup.yaml
@@ -39,7 +39,7 @@
       scenario: "{{ pipeline_type }}"
       scenario_os: "{{ pipeline_os }}"
       scenario_version: "{{ pipeline_version }}"
-      scenario_delay: "{{ pipeline_proxy_delay | default(0) }}"
+      scenario_version_offset: "{{ pipeline_proxy_version_offset | default(0) }}"
     - role: foreman_server_repositories
 
 - name: install packages

--- a/roles/forklift_versions/library/forklift_versions.py
+++ b/roles/forklift_versions/library/forklift_versions.py
@@ -59,7 +59,7 @@ def main():
             scenario=dict(type='str', required=True, choices=['foreman', 'katello', 'luna', 'plugins']),
             scenario_version=dict(type='str', required=True),
             scenario_os=dict(type='str', required=True),
-            scenario_delay=dict(type='int', default=0),
+            scenario_version_offset=dict(type='int', default=0),
             upgrade=dict(type='bool', default=False),
             upgrade_step=dict(type='int', default=1),
         ),
@@ -71,7 +71,7 @@ def main():
     scenario = SCENARIO_MAP.get(module.params['scenario'], module.params['scenario'])
     scenario_os = module.params['scenario_os']
     scenario_version = module.params['scenario_version']
-    scenario_delay = module.params['scenario_delay']
+    scenario_version_offset = module.params['scenario_version_offset']
 
     with open(module.params['file'], 'r') as versions_file:
         versions = yaml.safe_load(versions_file)
@@ -93,7 +93,7 @@ def main():
                 forklift_vars['pulpcore_repositories_version'] = version['pulpcore']
             all_forklift_vars.append(forklift_vars)
             if version[scenario] == scenario_version:
-                ret = all_forklift_vars[-(scenario_delay+1)]
+                ret = all_forklift_vars[-(scenario_version_offset+1)]
                 break
     else:
         possible_versions = set()

--- a/roles/forklift_versions/molecule/default/verify.yml
+++ b/roles/forklift_versions/molecule/default/verify.yml
@@ -37,6 +37,20 @@
           - katello_repositories_version == '3.17'
           - pulpcore_repositories_version == '3.7'
 
+    - name: "Include forklift_versions for 3.17 installs with delay"
+      include_role:
+        name: "forklift_versions"
+      vars:
+        scenario: "{{ pipeline_type }}"
+        scenario_os: "{{ pipeline_os }}"
+        scenario_version: "3.17"
+        scenario_delay: 1
+    - name: Ensure versions have been set correctly
+      assert:
+        that:
+          - foreman_repositories_version == '2.1'
+          - katello_repositories_version == '3.16'
+
     - name: "Include forklift_versions for nightly installs"
       include_role:
         name: "forklift_versions"

--- a/roles/forklift_versions/molecule/default/verify.yml
+++ b/roles/forklift_versions/molecule/default/verify.yml
@@ -44,7 +44,7 @@
         scenario: "{{ pipeline_type }}"
         scenario_os: "{{ pipeline_os }}"
         scenario_version: "3.17"
-        scenario_delay: 1
+        scenario_version_offset: 1
     - name: Ensure versions have been set correctly
       assert:
         that:

--- a/roles/forklift_versions/tasks/versions.yml
+++ b/roles/forklift_versions/tasks/versions.yml
@@ -5,7 +5,7 @@
     scenario: "{{ scenario }}"
     scenario_version: "{{ scenario_version }}"
     scenario_os: "{{ scenario_os }}"
-    scenario_delay: "{{ scenario_delay | default(omit) }}"
+    scenario_version_offset: "{{ scenario_version_offset | default(omit) }}"
   register: forklift_versions
   delegate_to: localhost
   become: no

--- a/roles/forklift_versions/tasks/versions.yml
+++ b/roles/forklift_versions/tasks/versions.yml
@@ -5,6 +5,7 @@
     scenario: "{{ scenario }}"
     scenario_version: "{{ scenario_version }}"
     scenario_os: "{{ scenario_os }}"
+    scenario_delay: "{{ scenario_delay | default(omit) }}"
   register: forklift_versions
   delegate_to: localhost
   become: no


### PR DESCRIPTION
this can be used to install a version n server with an n-1 proxy