### PR TITLE
remove option --ostree enable

### DIFF
--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -4,7 +4,7 @@ server_box:
   ansible:
     variables:
       foreman_server_repositories_katello: true
-      foreman_server_repositories_ostree: true
+      foreman_server_repositories_ostree: false
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: katello
       foreman_installer_additional_packages:
@@ -21,7 +21,7 @@ proxy_box:
   ansible:
     variables:
       foreman_server_repositories_katello: true
-      foreman_server_repositories_ostree: true
+      foreman_server_repositories_ostree: false
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: foreman-proxy-content
       foreman_installer_additional_packages:

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -4,7 +4,7 @@ server_box:
   ansible:
     variables:
       foreman_server_repositories_katello: true
-      foreman_server_repositories_ostree: true
+      foreman_server_repositories_ostree: false
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: katello
       foreman_installer_additional_packages:
@@ -40,7 +40,7 @@ proxy_box:
   ansible:
     variables:
       foreman_server_repositories_katello: true
-      foreman_server_repositories_ostree: true
+      foreman_server_repositories_ostree: false
       foreman_installer_disable_system_checks: true
       foreman_installer_scenario: foreman-proxy-content
       foreman_installer_additional_packages:

--- a/playbooks/bats_pipeline_katello_nightly.yml
+++ b/playbooks/bats_pipeline_katello_nightly.yml
@@ -12,7 +12,6 @@
     foreman_installer_disable_system_checks: true
     foreman_installer_options_internal_use_only:
       - "--foreman-initial-admin-password {{ foreman_installer_admin_password }}"
-      - "--katello-enable-ostree=true"
       - "--puppet-server-max-active-instances 1"
       - "--puppet-server-jvm-min-heap-size 1G"
       - "--puppet-server-jvm-max-heap-size 1G"

--- a/playbooks/foreman_proxy_content.yml
+++ b/playbooks/foreman_proxy_content.yml
@@ -3,7 +3,7 @@
   become: true
   vars:
     foreman_server_repositories_katello: true
-    foreman_server_repositories_ostree: true
+    foreman_server_repositories_ostree: false
     foreman_proxy_content_server_group: "server-{{ inventory_hostname }}"
     foreman_proxy_content_server: "{{ groups[foreman_proxy_content_server_group][0] }}"
   roles:
@@ -16,7 +16,7 @@
       foreman_installer_disable_system_checks: true
       foreman_installer_options_internal_use_only:
         - '--certs-tar-file "{{ foreman_proxy_content_certs_tar }}"'
-        - '--foreman-proxy-content-enable-ostree true'
+        - "{{ '' if (foreman_repositories_version == 'nightly' or 2.4 is version(foreman_repositories_version, '>')) else ('--foreman-proxy-content-enable-ostree true') }}"
         - '--foreman-proxy-trusted-hosts "{{ server_fqdn }}"'
         - '--foreman-proxy-trusted-hosts "{{ ansible_nodename }}"'
         - '--foreman-proxy-foreman-base-url "https://{{ server_fqdn }}"'

--- a/playbooks/foreman_proxy_content_dev.yml
+++ b/playbooks/foreman_proxy_content_dev.yml
@@ -5,7 +5,7 @@
     foreman_proxy_content_server_group: "server-{{ inventory_hostname }}"
     foreman_proxy_content_server: "{{ groups[foreman_proxy_content_server_group][0] }}"
     foreman_server_repositories_katello: true
-    foreman_server_repositories_ostree: true
+    foreman_server_repositories_ostree: false
     katello_repositories_version: nightly
   roles:
     - foreman_server_repositories
@@ -17,7 +17,7 @@
       foreman_installer_disable_system_checks: true
       foreman_installer_options_internal_use_only:
         - '--certs-tar-file "{{ foreman_proxy_content_certs_tar }}"'
-        - '--foreman-proxy-content-enable-ostree true'
+        - "{{ '' if (foreman_repositories_version == 'nightly' or 2.4 is version(foreman_repositories_version, '>')) else ('--foreman-proxy-content-enable-ostree true') }}"
         - '--foreman-proxy-trusted-hosts "{{ server_fqdn }}"'
         - '--foreman-proxy-trusted-hosts "{{ ansible_nodename }}"'
         - '--foreman-proxy-foreman-base-url "https://{{ server_fqdn }}"'

--- a/playbooks/luna-devel.yml
+++ b/playbooks/luna-devel.yml
@@ -3,7 +3,6 @@
   vars:
     foreman_installer_options:
       - "--katello-devel-github-username '{{ katello_devel_github_username }}'"
-      - "--katello-devel-enable-ostree=true"
       - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
       - "--katello-devel-extra-plugins theforeman/foreman_discovery"
       - "--katello-devel-extra-plugins theforeman/foreman_ansible"

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -22,6 +22,5 @@
       - "--enable-foreman-proxy-plugin-discovery"
       - "--enable-foreman-proxy-plugin-openscap"
       - "--enable-foreman-proxy-plugin-remote-execution-ssh"
-      - "--katello-enable-ostree true"
   roles:
     - role: katello

--- a/roles/katello/meta/main.yml
+++ b/roles/katello/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: foreman
     foreman_server_repositories_katello: true
-    foreman_server_repositories_ostree: true
+    foreman_server_repositories_ostree: false
     foreman_installer_scenario: katello
     foreman_installer_disable_system_checks: true
     foreman_installer_additional_packages:

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: etc_hosts
   - role: foreman_server_repositories
-    foreman_server_repositories_ostree: true
+    foreman_server_repositories_ostree: false
     foreman_server_repositories_katello: true
     foreman_server_repositories_foreman_client: true
   - role: ruby_scl


### PR DESCRIPTION
`"--katello-enable-ostree true"` this option does not exists.

I get error as:
```
TASK [foreman_installer : Run installer] ***************************************
fatal: [centos7-luna-devel]: FAILED! => changed=true 
  cmd: |-
    foreman-installer -v --no-colors --disable-system-checks --scenario katello-devel --katello-devel-github-username 'rabajaj0509' --ka
tello-devel-enable-ostree=true --katello-devel-extra-plugins theforeman/foreman_remote_execution --katello-devel-extra-plugins theforema
n/foreman_discovery --katello-devel-extra-plugins theforeman/foreman_ansible --katello-devel-extra-plugins theforeman/foreman-tasks --ka
tello-devel-extra-plugins theforeman/foreman_bootdisk --katello-devel-extra-plugins theforeman/foreman_openscap --katello-devel-extra-pl
ugins theforeman/foreman_templates --katello-devel-extra-plugins theforeman/foreman_hooks --katello-devel-scl-ruby=rh-ruby25 --katello-d
evel-admin-password changeme --katello-devel-extra-plugins theforeman/foreman_remote_execution
  delta: '0:00:08.423099'
  end: '2021-03-03 13:48:12.373727'
  msg: non-zero return code
  rc: 1
  start: '2021-03-03 13:48:03.950628'
  stderr: |-
    ERROR: Unrecognised option '--katello-devel-enable-ostree'
  

```