### PR TITLE
Add CentOS Stream 8 box config

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -28,3 +28,11 @@ boxes:
     scenarios:
       - foreman
       - katello
+
+  centos8-stream:
+    box_name: 'centos/stream8'
+    disk_size: 40
+    pty: true
+    scenarios:
+      - foreman
+      - katello

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -75,5 +75,6 @@ installers:
       - 'centos7'
       - 'centos7-fips'
       - 'centos8'
+      - 'centos8-stream'
       - 'debian10'
       - 'ubuntu1804'


### PR DESCRIPTION
Nightly Foreman is able to provision on CentOS 8 stream but then the installer fails because Apache can't read the Puppet certs. Currently Katello is broken in nightly so I can't check that, but it should be a goal to run.