### PR TITLE
Use postgresql_upgrade role from foreman-operations-collection for Fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Forklift provides tools to create Foreman/Katello environments for development, 
    - [Adding Custom Boxes](#adding-custom-boxes)
    - [Customize Deployment Settings](#customize-deployment-settings)
    - [Post Install Playbooks](#post-install-playbooks)
+   - [Using Local Ansible Collection](#using-local-ansible-collection)
  * [Production Environments](docs/production.md)
  * [Development Environments](docs/development.md)
  * [Stable Boxes](docs/stable_boxes.md)
@@ -25,7 +26,7 @@ Forklift provides tools to create Foreman/Katello environments for development, 
 ### Requirements
 
 * Vagrant - 2.2+ - Both the VirtualBox and Libvirt providers are tested
-* Ansible - 2.7+
+* Ansible - 2.9+
 * [Vagrant Libvirt provider plugin](https://github.com/vagrant-libvirt/vagrant-libvirt) (if using Libvirt)
 * Virtualization enabled in BIOS
 
@@ -38,6 +39,7 @@ This will walk through the simplest path of spinning up a production test enviro
 ```
 git clone https://github.com/theforeman/forklift.git
 cd forklift
+ansible-galaxy collection install -r requirements.yml
 vagrant up centos7-foreman-nightly
 ```
 
@@ -280,4 +282,20 @@ ansible:
     playbook:
       - 'user_playbooks/vim.yml'
       - 'user_playbooks/zsh.yml'
+```
+
+### Using Local Ansible Collection
+
+If needing to use a local copy of an Ansible collection used by Forklift, such as developing updates to theforeman.operations collection, you can temporarily update the `requirements.yml` to point at your local checkout:
+
+```
+collections:
+  - name: git+file:///home/user/path/to/repo/.git
+    type: git
+```
+
+Then run `ansible-galaxy` install:
+
+```
+ansible-galaxy collection install -r requirements.yml --force
 ```

--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -14,6 +14,7 @@
     forklift_url: "https://github.com/theforeman/forklift"
     forklift_dest: "{{ ansible_env.HOME }}/forklift"
     forklift_version: master
+    forklift_install_from_galaxy: True
     forklift_install_pulp_from_galaxy: False
     forklift_config:
       libvirt_options:
@@ -44,6 +45,12 @@
         dest: "{{ forklift_dest }}/vagrant/settings.yaml"
 
     - name: 'Install Forklift collection dependencies'
+      command:
+        cmd: ansible-galaxy collection install -r requirements.yml
+        chdir: "{{ forklift_dest }}"
+      when: forklift_install_from_galaxy
+
+    - name: 'Install Forklift Pulp collection dependencies'
       command:
         cmd: ansible-galaxy collection install -r requirements-pulp.yml
         chdir: "{{ forklift_dest }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - theforeman.operations

--- a/roles/foreman_installer/tasks/upgrade.yml
+++ b/roles/foreman_installer/tasks/upgrade.yml
@@ -7,6 +7,13 @@
   import_role:
     name: update_os_packages
 
+- name: 'Upgrade postgresql'
+  import_role:
+    name: theforeman.operations.postgresql_upgrade
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == '8'
+
 - include_tasks: installer_version.yml
 
 - name: 'Set internal installer options'


### PR DESCRIPTION
…reman upgrades

```
PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=5    changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
pipe-up-foreman-nightly-centos8 : ok=134  changed=37   unreachable=0    failed=0    skipped=87   rescued=0    ignored=2   
pipe-up-foreman-smoker-nightly-centos8 : ok=18   changed=13   unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   

ehelms@wareagle forklift (use-puppet-upgrade-foc)$ vagrant ssh pipe-up-foreman-nightly-centos8
sudo su
rpm -q postgresql*******************************************************************************
This is a private virtual machine that is the property of the Foreman project.
It is for authorized use only. Users (authorized or unauthorized) have no
explicit or implicit expectation of privacy.

Any or all uses of this system and all files on this system may be monitored,
recorded, copied, audited, or inspected.

LOG OFF IMMEDIATELY if you do not agree to the conditions stated in this
warning.
*******************************************************************************

CentOS 8.3.2011 x86_64

FQDN:      pipe-up-foreman-nightly-centos8.wareagle.example.com (192.168.122.235)
Processor: 2x Intel Core Processor (Skylake, IBRS)
Kernel:    4.18.0-240.1.1.el8_3.x86_64
Memory:    4.40 GiB


Last login: Mon Mar  8 18:43:52 2021 from 192.168.122.1
sudo su
rpm -q postgresql-[vagrant@pipe-up-foreman-nightly-centos8 ~]$ sudo su
s[root@pipe-up-foreman-nightly-centos8 vagrant]# rpm -q postgresql-server
postgresql-server-12.5-1.module_el8.3.0+620+f1abd701.x86_64
```