### PR TITLE
Add docker as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Options:
 | rackspace_options        |  sets Rackspace specific options |
 | openstack_options        |  sets OpenStack specific options |
 | google_options           |  sets Google specific options |
+| docker_options           |  sets Docker specific options |
 | domain                   |  forklift uses short name of your host + 'example.com' as domain name for your boxes. You can use this option to override it. |
 | sshfs                    |  if you have vagrant-sshfs plugin, you can use sshfs to share folders between your host and guest. See an example below for details. |
 | nfs                      |  share folders between host and guest.  See an example below for details. |

--- a/vagrant/.rubocop.yml
+++ b/vagrant/.rubocop.yml
@@ -14,6 +14,9 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Max: 325
 
+Metrics/BlockLength:
+  Max: 50
+
 Documentation:
   Enabled: false # don't require documentation
 

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -88,11 +88,7 @@ module Forklift
         networks = configure_networks(box.fetch('networks', []))
         configure_shell(machine, box)
         configure_ansible(machine, box['ansible'], box['name'])
-        configure_libvirt(machine, box, networks)
-        configure_virtualbox(machine, box, networks)
-        configure_rackspace(machine, box)
-        configure_openstack_provider(machine, box)
-        configure_google_provider(machine, box)
+        configure_providers(machine, box, networks)
         configure_synced_folders(machine, box)
         configure_private_network(machine, box)
         configure_sshfs(config, box)
@@ -238,6 +234,15 @@ module Forklift
       machine.vm.network :private_network, options
     end
 
+    def configure_providers(machine, box, networks = [])
+      configure_libvirt(machine, box, networks)
+      configure_virtualbox(machine, box, networks)
+      configure_rackspace(machine, box)
+      configure_openstack_provider(machine, box)
+      configure_google_provider(machine, box)
+      configure_docker_provider(machine, box)
+    end
+
     def configure_libvirt(machine, box, networks = [])
       machine.vm.provider :libvirt do |p, override|
         override.vm.box_url = box.fetch('libvirt') if box.fetch('libvirt', false)
@@ -336,6 +341,14 @@ module Forklift
         override.vm.box = 'google/gce'
 
         merged_options(box, 'google_options').each do |opt, val|
+          p.instance_variable_set("@#{opt}", val)
+        end
+      end
+    end
+
+    def configure_docker_provider(machine, box)
+      machine.vm.provider :docker do |p|
+        merged_options(box, 'docker_options').each do |opt, val|
           p.instance_variable_set("@#{opt}", val)
         end
       end


### PR DESCRIPTION
Pulp's forklift usage has a need for this to run a Pulp 2 docker
container on top of Pulp 3. And the docker provider supports docker
boxes nested on top of VM boxes.

See https://github.com/pulp/pulp_installer/pull/543 for our example
usage.