### PR TITLE
Fixes #32171 - consume Katello from yum.theforeman.org

### DIFF
--- a/roles/katello_repositories/tasks/release_repos.yml
+++ b/roles/katello_repositories/tasks/release_repos.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Setup Katello {{ katello_repositories_version }} Repository'
   yum:
-    name: https://fedorapeople.org/groups/katello/releases/yum/{{ katello_repositories_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm
+    name: https://{{ 'yum.theforeman.org/katello' if (katello_repositories_version == 'nightly' or katello_repositories_version is version('4.1', '>=')) else 'fedorapeople.org/groups/katello/releases/yum' }}/{{ katello_repositories_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm
     disable_gpg_check: True
     state: present


### PR DESCRIPTION
this currently checks for nightly or >= 4.1, as older versions are not
published on yum.tfm yet.