### PR TITLE
use pulpcore repo for katello 3.17

### DIFF
--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -55,10 +55,10 @@
   when:
     - katello_repositories_version != 'nightly'
     - katello_repositories_version is version('3.15', '>=')
-    - katello_repositories_version is version('3.17', '<=')
+    - katello_repositories_version is version('3.17', '<')
 
 - name: 'Add Pulpcore repository'
   include_role:
     name: pulpcore_repositories
   when:
-    - katello_repositories_version == "nightly" or katello_repositories_version is version('3.18', '>=')
+    - katello_repositories_version == "nightly" or katello_repositories_version is version('3.17', '>=')


### PR DESCRIPTION
this was configured in 5d9f7f2f, but the playbook was never adjusted,
thus breaking 3.17 fresh installs from the staging repo