### PR TITLE
always deploy our dedicated pulpcore repository for staging

### DIFF
--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -44,21 +44,6 @@
     - katello_repositories_pulp_version == "nightly"
     - ansible_distribution_major_version == '7'
 
-- name: 'Add Katello Pulpcore repository'
-  yum_repository:
-    name: pulpcore-repository
-    description: Pulpcore repository for Katello {{ katello_repositories_version }}
-    baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/pulpcore/el{{ ansible_distribution_major_version }}/x86_64/"
-    gpgcheck: no
-    enabled: yes
-    include: /etc/yum/foreman.conf
-  when:
-    - katello_repositories_version != 'nightly'
-    - katello_repositories_version is version('3.15', '>=')
-    - katello_repositories_version is version('3.17', '<')
-
 - name: 'Add Pulpcore repository'
   include_role:
     name: pulpcore_repositories
-  when:
-    - katello_repositories_version == "nightly" or katello_repositories_version is version('3.17', '>=')


### PR DESCRIPTION
staging repos are only used for the "version under test", and thus are
by definition only supported versions. no version prior to 3.17 is
supported anymore, so let's simplify the playbook.