### PR TITLE
Retry installing roles/collections

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -48,9 +48,15 @@
         cmd: ansible-galaxy collection install -r requirements-pulp.yml
         chdir: "{{ forklift_dest }}"
       when: forklift_install_pulp_from_galaxy
+      retries: 3
+      register: result
+      until: result is succeeded
 
     - name: 'Install Forklift pulp_installer role dependencies'
       command:
         cmd: ansible-galaxy role install -r playbooks/galaxy_collections/ansible_collections/pulp/pulp_installer/requirements.yml
         chdir: "{{ forklift_dest }}"
       when: forklift_install_pulp_from_galaxy
+      retries: 3
+      register: result
+      until: result is succeeded


### PR DESCRIPTION
We've been getting 520 status from Galaxy:
https://github.com/pulp/pulp_installer/runs/2214849111?check_suite_focus=true

Adding some retries for fixing the intermittent CI