### PR TITLE
Run remove-pulp2 command after upgrading to 4.0

### DIFF
--- a/pipelines/upgrade/05-server_to_intermediate.yaml
+++ b/pipelines/upgrade/05-server_to_intermediate.yaml
@@ -21,3 +21,11 @@
     - foreman_server_repositories
     - role: foreman_installer
       foreman_installer_skip_installer: "{{ true if forklift_upgrade_version_start == forklift_upgrade_version_intermediate else false }}"
+  post_tasks:
+    - name: Run remove Pulp 2
+      shell: yes | foreman-maintain content remove-pulp2
+      when:
+        - forklift_upgrade_version_intermediate == "4.0"
+        - pipeline_remove_pulp2
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version == "7"

--- a/pipelines/upgrade/06-proxy_to_intermediate.yaml
+++ b/pipelines/upgrade/06-proxy_to_intermediate.yaml
@@ -22,3 +22,11 @@
     - foreman_server_repositories
     - role: foreman_proxy_content
       when: forklift_upgrade_version_start != forklift_upgrade_version_intermediate
+  post_tasks:
+    - name: Run remove Pulp 2
+      shell: yes | foreman-maintain content remove-pulp2
+      when:
+        - forklift_upgrade_version_intermediate == "4.0"
+        - pipeline_remove_pulp2
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version == "7"

--- a/pipelines/upgrade/07-server_to_final.yaml
+++ b/pipelines/upgrade/07-server_to_final.yaml
@@ -20,3 +20,11 @@
       scenario_version: "{{ forklift_upgrade_version_final }}"
     - foreman_server_repositories
     - foreman_installer
+  post_tasks:
+    - name: Run remove Pulp 2
+      shell: yes | foreman-maintain content remove-pulp2
+      when:
+        - forklift_upgrade_version_final == "4.0"
+        - pipeline_remove_pulp2
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version == "7"

--- a/pipelines/upgrade/08-proxy_to_final.yaml
+++ b/pipelines/upgrade/08-proxy_to_final.yaml
@@ -21,3 +21,11 @@
       scenario_version: "{{ forklift_upgrade_version_final }}"
     - foreman_server_repositories
     - foreman_proxy_content
+  post_tasks:
+    - name: Run remove Pulp 2
+      shell: yes | foreman-maintain content remove-pulp2
+      when:
+        - forklift_upgrade_version_intermediate == "4.0"
+        - pipeline_remove_pulp2
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version == "7"

--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -15,6 +15,7 @@ server_box:
         - "--puppet-server-jvm-max-heap-size 1G"
       bats_tests_additional:
         - fb-katello-proxy.bats
+      pipeline_remove_pulp2: true
 proxy_box:
   box: "{{ pipeline_os }}"
   memory: 3072

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -34,6 +34,7 @@ server_box:
         - "fb-test-foreman-ansible.bats"
         - "fb-test-foreman-templates.bats"
         - "fb-katello-proxy.bats"
+      pipeline_remove_pulp2: true
 proxy_box:
   box: "{{ pipeline_os }}"
   memory: 3072


### PR DESCRIPTION
Given users are expected to run this at some point, and as we progress through the current Katello versions and those coming after, 