### PR TITLE
Only run fb-verify-packages on install

### DIFF
--- a/pipelines/vars/forklift_foreman.yml
+++ b/pipelines/vars/forklift_foreman.yml
@@ -9,7 +9,6 @@ server_box:
         - "--puppet-server-jvm-min-heap-size 1G"
         - "--puppet-server-jvm-max-heap-size 1G"
       bats_tests:
-        - "fb-verify-packages.bats"
         - "fb-test-foreman.bats"
         - "fb-test-puppet.bats"
       bats_teardown: []

--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -13,8 +13,13 @@ server_box:
         - "--puppet-server-max-active-instances 1"
         - "--puppet-server-jvm-min-heap-size 1G"
         - "--puppet-server-jvm-max-heap-size 1G"
-      bats_tests_additional:
-        - fb-katello-proxy.bats
+      bats_tests:
+        - "fb-test-foreman.bats"
+        - "fb-test-puppet.bats"
+        - "fb-test-katello.bats"
+        - "fb-katello-content.bats"
+        - "fb-katello-client.bats"
+        - "fb-katello-proxy.bats"
       pipeline_remove_pulp2: true
 proxy_box:
   box: "{{ pipeline_os }}"

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -29,7 +29,12 @@ server_box:
         - "--enable-foreman-plugin-templates"
         - "--enable-foreman-plugin-virt-who-configure"
         - "--foreman-proxy-plugin-remote-execution-ssh-install-key=true"
-      bats_tests_additional:
+      bats_tests:
+        - "fb-test-foreman.bats"
+        - "fb-test-puppet.bats"
+        - "fb-test-katello.bats"
+        - "fb-katello-content.bats"
+        - "fb-katello-client.bats"
         - "fb-test-foreman-rex.bats"
         - "fb-test-foreman-ansible.bats"
         - "fb-test-foreman-templates.bats"

--- a/pipelines/vars/forklift_plugins.yml
+++ b/pipelines/vars/forklift_plugins.yml
@@ -27,7 +27,6 @@ server_box:
         - "{{ '--enable-foreman-plugin-openscap' if pipeline_os.startswith('centos') else '' }}"
         - "{{ '--enable-foreman-proxy-plugin-openscap' if pipeline_os.startswith('centos') else '' }}"
       bats_tests:
-        - "fb-verify-packages.bats"
         - "fb-test-foreman.bats"
         - "fb-test-puppet.bats"
         - "fb-test-foreman-rex.bats"

--- a/pipelines/vars/install_base.yml
+++ b/pipelines/vars/install_base.yml
@@ -5,3 +5,5 @@ forklift_smoker_name: "pipe-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{
 smoker_box:
   box: centos7
   memory: 2048
+bats_tests_additional:
+  - "fb-verify-packages.bats"


### PR DESCRIPTION
In upgrades old packages can still be present. That's why we only test it on fresh installs. Additionally, it now also runs it on the plugins pipeline.