### PR TITLE
Enable Ruby 2.7 on foreman-proxy-content upgrade

### DIFF
--- a/roles/foreman_proxy_content/tasks/upgrade.yml
+++ b/roles/foreman_proxy_content/tasks/upgrade.yml
@@ -4,8 +4,8 @@
 - name: 'Run installer upgrade'
   include_role:
     name: foreman_installer
-    tasks_from: upgrade
   vars:
+    foreman_installer_upgrade: true
     foreman_installer_scenario: foreman-proxy-content
     foreman_installer_disable_system_checks: True
     foreman_installer_options_internal_use_only:


### PR DESCRIPTION
When only the upgrade tasks were included, additional, important logic was missed in the installer role such as setting up Ruby 2.7 on upgrade.