### PR TITLE
Group plugins in Luna scenario

### DIFF
--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -13,26 +13,36 @@ server_box:
         - "--puppet-server-max-active-instances 1"
         - "--puppet-server-jvm-min-heap-size 1G"
         - "--puppet-server-jvm-max-heap-size 1G"
+
         - "--enable-foreman-cli-ansible"
-        - "--enable-foreman-cli-discovery"
-        - "--enable-foreman-cli-openscap"
-        - "--enable-foreman-cli-remote-execution"
-        - "--enable-foreman-cli-tasks"
-        - "--enable-foreman-cli-templates"
-        - "--enable-foreman-cli-virt-who-configure"
         - "--enable-foreman-plugin-ansible"
-        - "--enable-foreman-plugin-bootdisk"
-        - "--enable-foreman-plugin-discovery"
-        - "--enable-foreman-plugin-hooks"
-        - "--enable-foreman-plugin-openscap"
-        - "--enable-foreman-plugin-remote-execution"
-        - "--enable-foreman-plugin-templates"
-        - "--enable-foreman-plugin-virt-who-configure"
         - "--enable-foreman-proxy-plugin-ansible"
+
+        - "--enable-foreman-plugin-bootdisk"
+
+        - "--enable-foreman-cli-discovery"
+        - "--enable-foreman-plugin-discovery"
         - "--enable-foreman-proxy-plugin-discovery"
+
+        - "--enable-foreman-plugin-hooks"
+
+        - "--enable-foreman-cli-openscap"
+        - "--enable-foreman-plugin-openscap"
         - "--enable-foreman-proxy-plugin-openscap"
+
+        - "--enable-foreman-cli-remote-execution"
+        - "--enable-foreman-plugin-remote-execution"
         - "--enable-foreman-proxy-plugin-remote-execution-ssh"
         - "--foreman-proxy-plugin-remote-execution-ssh-install-key=true"
+
+        - "--enable-foreman-cli-tasks"
+        - "--enable-foreman-plugin-tasks"
+
+        - "--enable-foreman-cli-templates"
+        - "--enable-foreman-plugin-templates"
+
+        - "--enable-foreman-cli-virt-who-configure"
+        - "--enable-foreman-plugin-virt-who-configure"
       bats_tests_additional:
         - "fb-test-foreman-rex.bats"
         - "fb-test-foreman-ansible.bats"


### PR DESCRIPTION
This groups all options by plugin rather than just sorting alphabetically. This makes it easier to see which plugins are enabled.