### PR TITLE
Do not use taxonomy flags with compute profiles

### DIFF
--- a/roles/foreman_provisioning_infrastructure/tasks/compute_profiles.yml
+++ b/roles/foreman_provisioning_infrastructure/tasks/compute_profiles.yml
@@ -9,8 +9,6 @@
   shell: >
     {{ foreman_provisioning_hammer }} compute-profile create
     --name "libvirt-profile"
-    --organization "{{ foreman_provisioning_organization }}"
-    --location "{{ foreman_provisioning_location }}"
   when: "'Error' in foreman_provisioning_compute_profile.stderr"
 
 - name: 'create compute attributes'


### PR DESCRIPTION
After #31384, passing --organization[-id]
options to `compute-profile create`
returns an unrecognized option error.
Compute profiles are not taxable anyway.