### PR TITLE
Unlock packages after enabling katello-agent

### DIFF
--- a/bats/fb-katello-client.bats
+++ b/bats/fb-katello-client.bats
@@ -91,6 +91,7 @@ load fixtures/content
     skip "Enabling katello-agent explicitly is only available with Katello 4.1+"
   fi
   foreman-installer --foreman-proxy-content-enable-katello-agent true
+  foreman-maintain packages unlock -y
 }
 
 @test "install katello-agent" {


### PR DESCRIPTION
If the installer scenario is using the packages lock feature the
subsequent tests will fail as package installs are blocked.