### PR TITLE
use hammer puppet-environment

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -66,8 +66,8 @@ fi
   [ $count -gt 1 ]
 }
 
-@test "Assign environment to default taxonomies" {
-  hammer environment update --name=production --locations "Default Location" --organizations "Default Organization"
+@test "Assign puppet-environment to default taxonomies" {
+  hammer puppet-environment update --name=production --locations "Default Location" --organizations "Default Organization"
 }
 
 @test "Assign proxy to default taxonomies" {


### PR DESCRIPTION
hammer environment was deprecated since hammer 0.18 (Foreman 1.23) and
is now removed in nightly