### PR TITLE
Fetch old /pulp/repos/ path in bats

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -365,3 +365,11 @@ setup() {
   hammer docker manifest list --content-view-version-id=$cvv_id --fields="schema version,digest,tags" \
     --order='tag' | grep 'sha256:13280b5914050853a87d662c3229d42b61544e36dd4515f06e188835f3407468'
 }
+
+@test "fetch rpm from yum repository on old path" {
+  URL1="http://$HOSTNAME/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
+  URL2="http://$HOSTNAME/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
+  (cd /tmp; curl -f -L -O $URL1 || curl -f -L -O $URL2)
+  tFileExists /tmp/walrus-0.71-1.noarch.rpm && rpm -qp /tmp/walrus-0.71-1.noarch.rpm
+  tFileExists /tmp/walrus-0.71-1.noarch.rpm && rm /tmp/walrus-0.71-1.noarch.rpm
+}

--- a/bats/fb-katello-proxy.bats
+++ b/bats/fb-katello-proxy.bats
@@ -26,9 +26,18 @@ setup() {
   hammer capsule content synchronize --id=$PROXY_ID
 }
 
-@test "content is available from proxy" {
+@test "content is available from proxy using old /pulp/repos" {
   URL1="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
   URL2="http://${PROXY_HOSTNAME}/pulp/repos/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
   (cd /tmp; curl -f -L -O $URL1 || curl -f -L -O $URL2)
   tFileExists /tmp/walrus-0.71-1.noarch.rpm && rpm -qp /tmp/walrus-0.71-1.noarch.rpm
+  tFileExists /tmp/walrus-0.71-1.noarch.rpm && rm /tmp/walrus-0.71-1.noarch.rpm
+}
+
+@test "content is available from proxy using /pulp/content" {
+  URL1="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
+  URL2="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
+  (cd /tmp; curl -f -L -O $URL1 || curl -f -L -O $URL2)
+  tFileExists /tmp/walrus-0.71-1.noarch.rpm && rpm -qp /tmp/walrus-0.71-1.noarch.rpm
+  tFileExists /tmp/walrus-0.71-1.noarch.rpm && rm /tmp/walrus-0.71-1.noarch.rpm
 }


### PR DESCRIPTION
the /pulp/repos path is around to make sure that old clients
still work, this adds a bats test to ensure that.  It also
verifies that /pulp/content/ works on smart proxies