### PR TITLE
Enable smart proxy dynflow + rex ssh in katello devel

### DIFF
--- a/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
@@ -36,9 +36,9 @@ foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::dns::powerdns: false
-foreman_proxy::plugin::dynflow: false
+foreman_proxy::plugin::dynflow: true
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::omaha: false
 foreman_proxy::plugin::openscap: false
-foreman_proxy::plugin::remote_execution::ssh: false
+foreman_proxy::plugin::remote_execution::ssh: true
 foreman_proxy::plugin::salt: false


### PR DESCRIPTION
This enables the smart proxy pieces to use REX in katello devel with an important byproduct being generated SSH keys that can be placed on client hosts to enable the connection.

Future work might include updating the katello client role to copy the pubkey into authorized_keys automatically