### PR TITLE
Creating a role foreman_maintain_packages to be used during a sosreport execution

### DIFF
--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -6,6 +6,7 @@
     remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
     smoker_output_dir: '/home/vagrant/smoker'
   roles:
+    - foreman_maintain_packages
     - sos_report
   tasks:
     - name: "Find bats files"

--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -5,13 +5,8 @@
     bats_output_dir: '/root/bats_results'
     remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
     smoker_output_dir: '/home/vagrant/smoker'
-  pre_tasks:
-    - name: Gather the package facts
-      package_facts:
-        manager: auto
   roles:
     - role: foreman_maintain_packages
-      when: "'rubygem-foreman_maintain' in ansible_facts.packages"
     - role: sos_report
   tasks:
     - name: "Find bats files"

--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -5,9 +5,14 @@
     bats_output_dir: '/root/bats_results'
     remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
     smoker_output_dir: '/home/vagrant/smoker'
+  pre_tasks:
+    - name: Gather the package facts
+      package_facts:
+        manager: auto
   roles:
-    - foreman_maintain_packages
-    - sos_report
+    - role: foreman_maintain_packages
+      when: "'rubygem-foreman_maintain' in ansible_facts.packages"
+    - role: sos_report
   tasks:
     - name: "Find bats files"
       find:

--- a/roles/foreman_maintain_packages/tasks/main.yaml
+++ b/roles/foreman_maintain_packages/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: Gather the package facts
+  package_facts:
+    manager: auto
 - name: 'Allow Packages to be Installed'
-  command: "foreman-maintain packages unlock -y"  
+  command: "foreman-maintain packages unlock -y" 
+  when: "'rubygem-foreman_maintain' in ansible_facts.packages"

--- a/roles/foreman_maintain_packages/tasks/main.yaml
+++ b/roles/foreman_maintain_packages/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: 'Allow Packages to be Installed'
+  command: "foreman-maintain packages unlock -y"  


### PR DESCRIPTION
This PR adds one role that executes `foreman-maintain packages unlock -y`, with this we can ensure that the packages sos/sosreport will be installed during the execution of `playbooks/collect_debug.yml`

I already tested against one box running `centos7-katello-4.0` where `foreman-maintain packages lock` was enabled:

```
$ ansible-playbook --limit '!localhost' playbooks/collect_debug.yml  -vv
TASK [foreman_maintain_packages : Allow Packages to be Installed] ************************
[1;30mtask path: /home/osousa/code/sat/forklift/roles/foreman_maintain_packages/tasks/main.yaml:2[0m
[0;33mchanged: [centos7-katello-4.0] => changed=true [0m
[0;33m  cmd:[0m
[0;33m  - foreman-maintain[0m
[0;33m  - packages[0m
[0;33m  - unlock[0m
[0;33m  - -y[0m
[0;33m  delta: '0:00:02.702065'[0m
[0;33m  end: '2021-06-04 19:00:52.665717'[0m
[0;33m  rc: 0[0m
[0;33m  start: '2021-06-04 19:00:49.963652'[0m
[0;33m  stderr: ''[0m
[0;33m  stderr_lines: <omitted>[0m
[0;33m  stdout: |-[0m
[0;33m    Running preparation steps required to run the next scenarios[0m
[0;33m    ================================================================================[0m
[0;33m    Check if tooling for package locking is installed:                    [32m[1m[OK][0m[0m
[0;33m    --------------------------------------------------------------------------------[0m
[0;33m  [0m
[0;33m  [0m
[0;33m    Running unlocking of package versions[0m
[0;33m    ================================================================================[0m
[0;33m    Unlock packages:                                                      [32m[1m[OK][0m[0m
[0;33m    --------------------------------------------------------------------------------[0m
[0;33m  stdout_lines: <omitted>[0m
[0;32m [started TASK: sos_report : Load OS variables on centos7-katello-4.0][0m
```