### PR TITLE
Fix empty else error for katello github username

### DIFF
--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -20,6 +20,6 @@ dependencies:
     foreman_installer_options_internal_use_only:
       - "{{ '--katello-devel-scl-ruby=' +  ruby_scl_version if ansible_distribution_major_version == '7' else '' }}"
       - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"
-      - "{{ '--katello-devel-github-username=' + katello_devel_github_username if katello_devel_github_username is defined }}"
+      - "{{ '--katello-devel-github-username=' + katello_devel_github_username if katello_devel_github_username is defined else '' }}"
       - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
   - role: customize_home


### PR DESCRIPTION
Seems the version of ansible on my centos box (2.9.6) wasn't happy while Fedora (2.9.21) was A-OK with it!