### PR TITLE
skip /pulp/content tests on Pulp2 installs

### DIFF
--- a/bats/fb-katello-proxy.bats
+++ b/bats/fb-katello-proxy.bats
@@ -35,6 +35,7 @@ setup() {
 }
 
 @test "content is available from proxy using /pulp/content" {
+  tSkipIfPulp2
   URL1="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
   URL2="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
   (cd /tmp; curl -f -L -O $URL1 || curl -f -L -O $URL2)

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -45,6 +45,12 @@ tSkipIfNoPulp2() {
   fi
 }
 
+tSkipIfPulp2() {
+  if tIsPulp2; then
+    skip "${1} is not available in scenarios with Pulp 2"
+  fi
+}
+
 tSkipIfHammerBelow018() {
   if tPackageExists tfm-rubygem-hammer_cli; then
     RPM_PACKAGE=tfm-rubygem-hammer_cli


### PR DESCRIPTION
Pulp2 doesn't know about /pulp/content, and thus fails tests on such
installs