### PR TITLE
rename tSkipIfPulp2 to tSkipIfNotPulp3Only

### DIFF
--- a/bats/fb-katello-proxy.bats
+++ b/bats/fb-katello-proxy.bats
@@ -35,7 +35,7 @@ setup() {
 }
 
 @test "content is available from proxy using /pulp/content" {
-  tSkipIfPulp2 "/pulp/content"
+  tSkipIfNotPulp3Only "/pulp/content"
   URL1="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/walrus-0.71-1.noarch.rpm"
   URL2="http://${PROXY_HOSTNAME}/pulp/content/${ORGANIZATION_LABEL}/Library/${CONTENT_VIEW_LABEL}/custom/${PRODUCT_LABEL}/${YUM_REPOSITORY_LABEL}/Packages/w/walrus-0.71-1.noarch.rpm"
   (cd /tmp; curl -f -L -O $URL1 || curl -f -L -O $URL2)

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -39,7 +39,7 @@ tIsPulp2() {
   tPackageExists pulp-server
 }
 
-tSkipIfPulp2() {
+tSkipIfNotPulp3Only() {
   if tIsPulp2; then
     skip "${1} is not available in scenarios with Pulp 2"
   fi


### PR DESCRIPTION
this is the result of the discussion in https://github.com/theforeman/forklift/pull/1373#discussion_r655197960

but I am still not *really* happy about the naming.

@ekohl originally suggested `tSkipIfNoPulp3` (and `tSkipUnlessPulp3ServesRPM`).

I think the later is the most correct one, but I don't see a good way to determine that, and if we go by the presence of the `pulp-server` RPM (or the Katello version), we really check "is that a pulp3-only install, or not".