### PR TITLE
Update default Pulp repositories and nightly to 3.14

### DIFF
--- a/roles/pulpcore_repositories/defaults/main.yml
+++ b/roles/pulpcore_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-pulpcore_repositories_version: '3.11'
+pulpcore_repositories_version: '3.14'

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -83,7 +83,7 @@ installers:
   - foreman: 'nightly'
     katello: 'nightly'
     pulp: '2.21'
-    pulpcore: '3.11'
+    pulpcore: '3.14'
     puppet: 6
     boxes:
       - 'centos7'


### PR DESCRIPTION
The current state of nightly expects this due to changes in puppet-pulpcore. We can hold this for 3.14 or merge now and then update again. I was hitting this testing nightly and so might others.