### PR TITLE
Add module_hotfixes=1 for pulpcore repositories

### DIFF
--- a/roles/pulpcore_repositories/tasks/main.yml
+++ b/roles/pulpcore_repositories/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: 'Create module_hotfixes config file'
+  copy:
+    dest: /etc/yum/pulpcore.conf
+    content: |
+      module_hotfixes=1
+
 - name: "Add Pulpcore {{ pulpcore_repositories_version }} repository"
   yum_repository:
     name: pulpcore-repository
@@ -6,3 +12,4 @@
     baseurl: "https://yum.theforeman.org/pulpcore/{{ pulpcore_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
     gpgcheck: no
     enabled: yes
+    include: /etc/yum/pulpcore.conf


### PR DESCRIPTION
I got this for you @evgeni 

```
16:00:25  [0;31m    2021-07-08 19:49:24 [NOTICE] [configure] Starting system configuration.[0m
16:00:25  [0;31m    2021-07-08 19:50:44 [NOTICE] [configure] 250 configuration steps out of 1888 steps complete.[0m
16:00:25  [0;31m    2021-07-08 19:51:46 [NOTICE] [configure] 500 configuration steps out of 1890 steps complete.[0m
16:00:25  [0;31m    2021-07-08 19:51:48 [NOTICE] [configure] 750 configuration steps out of 1892 steps complete.[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] Execution of '/bin/dnf -d 0 -e 1 -y install python3-pulp-ansible' returned 1: Error:[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] Problem: package python3-galaxy-importer-0.3.2-1.el8.noarch requires ansible-lint >= 5.0.8, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-galaxy-importer-0.3.2-1.el8.noarch requires ansible-lint < 6.0, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package ansible-lint-5.0.8-1.el8.noarch requires python3-rich >= 9.5.1, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-pulp-ansible-1:0.8.0-1.el8.noarch requires python3-galaxy-importer >= 0.3.1, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-rich-10.0.1-1.el8.noarch requires python3-pygments >= 2.6.0, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - conflicting requests[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-pygments-2.8.1-1.el8.noarch is filtered out by modular filtering[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] /Stage[main]/Pulpcore::Plugin::Ansible/Pulpcore::Plugin[ansible]/Package[python3-pulp-ansible]/ensure: change from 'purged' to 'present' failed: Execution of '/bin/dnf -d 0 -e 1 -y install python3-pulp-ansible' returned 1: Error:[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] Problem: package python3-galaxy-importer-0.3.2-1.el8.noarch requires ansible-lint >= 5.0.8, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-galaxy-importer-0.3.2-1.el8.noarch requires ansible-lint < 6.0, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package ansible-lint-5.0.8-1.el8.noarch requires python3-rich >= 9.5.1, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-pulp-ansible-1:0.8.0-1.el8.noarch requires python3-galaxy-importer >= 0.3.1, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-rich-10.0.1-1.el8.noarch requires python3-pygments >= 2.6.0, but none of the providers can be installed[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - conflicting requests[0m
16:00:25  [0;31m    2021-07-08 19:52:06 [ERROR ] [configure] - package python3-pygments-2.8.1-1.el8.noarch is filtered out by modular filtering[0m
16:00:25  [0;31m    2021-07-08 19:52:19 [NOTICE] [configure] 1000 configuration steps out of 1898 steps complete.[0m
16:00:25  [0;31m    2021-07-08 19:52:23 [NOTICE] [configure] 1250 configuration steps out of 1919 steps complete.[0m
16:00:25  [0;31m    2021-07-08 19:58:46 [NOTICE] [configure] 1500 configuration steps out of 1919 steps complete.[0m
16:00:25  [0;31m    2021-07-08 20:00:08 [NOTICE] [configure] 1750 configuration steps out of 1919 steps complete.[0m
16:00:25  [0;31m    2021-07-08 20:00:12 [NOTICE] [configure] System configuration has finished.[0m
```