### PR TITLE
accept both puppet.com and puppetlabs.com as package origin

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -16,10 +16,10 @@ fi
 
 @test "assert puppet version" {
   if tIsRedHatCompatible ; then
-    run grep -q puppetlabs /etc/yum.repos.d/*.repo
+    run grep -q -E 'puppet(labs)?\.com' /etc/yum.repos.d/*.repo
     IS_NATIVE=$status
   elif tIsDebianCompatible ; then
-    run grep -q puppet\.com -R /etc/apt/sources.list*
+    run grep -q -E 'puppet(labs)?\.com' -R /etc/apt/sources.list*
     IS_NATIVE=$status
   else
     IS_NATIVE=1


### PR DESCRIPTION
Puppet renamed from Puppetlabs a while ago, but their release packages
still refer to puppetlabs.com to download packages.

We have switched to use the release packages on Debian now, which broke
the "native" detection.