### PR TITLE
properly skip content-export tests on 4.0 and older

### DIFF
--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -29,7 +29,8 @@ tKatelloVersion() {
 }
 
 tSkipIfOlderThan41() {
-  if [[ tKatelloVersion < 4.1 ]]; then
+  KATELLO_VERSION=$(tKatelloVersion)
+  if [[ $KATELLO_VERSION != 4.* || $KATELLO_VERSION == 4.0 ]]; then
     skip "pulpcore import/export tests are not available on Katello versions older than 4.1"
   fi
 }


### PR DESCRIPTION
< doesn't work reliably on numbers