### PR TITLE
Only delete import+exports orgs when katello is < 4.1

### DIFF
--- a/bats/fb-destroy-organization.bats
+++ b/bats/fb-destroy-organization.bats
@@ -16,9 +16,11 @@ setup() {
 }
 
 @test "Delete Import Organization" {
+  tSkipIfOlderThan41
   hammer organization delete --name="${IMPORT_ORG}"
 }
 
 @test "Delete Library Import Organization" {
+  tSkipIfOlderThan41
   hammer organization delete --name="${LIBRARY_IMPORT_ORG}"
 }


### PR DESCRIPTION
The 3.18 pipeline got confused :)

https://ci.theforeman.org/job/katello-3.18-rpm-pipeline/25/tapTestReport/

cc @ehelms @evgeni 