### PR TITLE
correct katello 3.18-el8 skip test

### DIFF
--- a/roles/forklift_versions/molecule/default/verify.yml
+++ b/roles/forklift_versions/molecule/default/verify.yml
@@ -97,18 +97,17 @@
           - forklift_upgrade_version_intermediate == '2.1'
           - forklift_upgrade_version_final == '2.2'
 
-    # this will fail once 4.1 is out and nightly is 4.2
     - name: "Include forklift_versions for Katello EL8 upgrades"
       include_role:
         name: "forklift_versions"
       vars:
         scenario: "{{ pipeline_type }}"
         scenario_os: "centos8"
-        scenario_version: "nightly"
+        scenario_version: "4.1"
         upgrade: True
     - name: Ensure 3.18 was properly skipped
       assert:
         that:
-          - forklift_upgrade_version_start == '4.1'
-          - forklift_upgrade_version_intermediate == '4.2'
-          - forklift_upgrade_version_final == 'nightly'
+          - forklift_upgrade_version_start == '4.0'
+          - forklift_upgrade_version_intermediate == '4.0'
+          - forklift_upgrade_version_final == '4.1'


### PR DESCRIPTION
the test is supposed to test that 3.18 is correctly skipped for upgrades
on el8 when the target is 4.1 (aka: something that would include 3.18 in
the upgrade path). testing it on nightly, where the upgrade is
4.0→4.1→nightly is not useful.

Fixes: 5a0e44407801c13a65de9f8a1e1127ec73db38de