### PR TITLE
pin pulp_installer to 3.14.3-1

### DIFF
--- a/requirements-pulp.yml
+++ b/requirements-pulp.yml
@@ -1,2 +1,3 @@
 collections:
-  - pulp.pulp_installer
+  - name: pulp.pulp_installer
+    version: 3.14.3-1


### PR DESCRIPTION
galaxy consideres 3.14.3-1 lower than 3.14.3, but -1 includes a fix that
is needed for our pipelines