### PR TITLE
Remove goferd after katello-client tests

### DIFF
--- a/bats/fb-katello-client.bats
+++ b/bats/fb-katello-client.bats
@@ -118,6 +118,7 @@ load fixtures/content
   timeout 300 hammer host package remove --host $HOSTNAME --packages walrus
 }
 
-@test "cleanup subscription-manager after content tests" {
+@test "clean up subscription-manager and gofer after content tests" {
   cleanSubscriptionManager
+  tPackageRemove gofer
 }


### PR DESCRIPTION
This fixes an issue that has come up in the nightly pipeline where goferd is installed and running, but katello-agent has been removed - presumably after some initial run of the katello-client tests. when the katello-client tests run again katello-agent is installed but gofer doesn't auto-detect the agent plugin which causes the subsequent tests to fail. this fixes that by removing gofer after the client tests run

bonus: only run the installer to enable katello-agent if qpid is not installed already