### PR TITLE
set pulp_pkg_name_prefix to the correct Python 3.8 prefix for 3.15+

### DIFF
--- a/pipelines/vars/forklift_pulpcore.yml
+++ b/pipelines/vars/forklift_pulpcore.yml
@@ -22,3 +22,6 @@ pulp_install_plugins_314:
   pulp-python: {}
 pulp_install_plugins: "{{ pulp_install_plugins_base | combine(pulp_install_plugins_314 if pipeline_version is version('3.14', '>=') else {}) }}"
 pulp_default_admin_password: password
+pulp_pkg_name_prefix_py36: "python3-"
+pulp_pkg_name_prefix_py38: "{{ 'python38-' if pipeline_os == 'centos8' else 'tfm-pulpcore-python3-' }}"
+pulp_pkg_name_prefix: "{{ pulp_pkg_name_prefix_py38 if pipeline_version is version('3.15', '>=') else pulp_pkg_name_prefix_py36 }}"


### PR DESCRIPTION
Requires https://github.com/pulp/pulp_installer/pull/758