### PR TITLE
Remove gem-compare dependency in packaging box

### DIFF
--- a/playbooks/rpm_packaging.yml
+++ b/playbooks/rpm_packaging.yml
@@ -31,13 +31,6 @@
         state: present
       become: true
 
-    - name: Install gem-compare
-      gem:
-        name: gem-compare
-        user_install: false
-        state: present
-      become: true
-
     - name: Clone foreman-packaging
       git:
         repo: https://github.com/theforeman/foreman-packaging.git


### PR DESCRIPTION
In rpm/develop this is [no longer needed](https://github.com/theforeman/foreman-packaging/commit/71c11e00084045b718ffdef9b17c5ac9e727c86b).