### PR TITLE
To workaround errors when installing a proxy devel image, disable puppet

### DIFF
--- a/playbooks/foreman_proxy_content_dev.yml
+++ b/playbooks/foreman_proxy_content_dev.yml
@@ -24,4 +24,8 @@
         - '--foreman-proxy-register-in-foreman true'
         - '--foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key }}"'
         - '--foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret }}"'
+        - "--no-enable-puppet"
+        - "--foreman-proxy-puppet false"
+        - "--foreman-proxy-puppetca false"
+        - "--foreman-proxy-content-puppet false"
         - "{{ '' if (foreman_repositories_version == 'nightly' or 2.3 is version(foreman_repositories_version, '>')) else ('--foreman-proxy-content-parent-fqdn %s' % server_fqdn) }}"


### PR DESCRIPTION
I am not certain if the installer options I added are in the right place, but I did use them locally. Without these changes, I run into errors when provisioning the proxy-devel vm.

For example:
```
variables:
        foreman_installer_options:
          - "--no-enable-puppet"
          - "--foreman-proxy-puppet false"
          - "--foreman-proxy-puppetca false"
          - "--foreman-proxy-content-puppet false"
```