### PR TITLE
Remove suggestion of using github username for dev boxes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -24,12 +24,10 @@ This covers how to setup and configure a development environment using the Forkl
 A Katello development environment can be deployed on CentOS 7. Ensure that you have followed the steps to setup Vagrant and the libvirt plugin. There are a variety of useful development environment options that should or can be set when creating a development box. These options are designed to configure your environment ready to use your own fork, and create pull requests. To create a development box:
 
 1. Copy `vagrant/boxes.d/99-local.yaml.example` to `vagrant/boxes.d/99-local.yaml`. If you already have a `99-local.yaml`, you can copy the entries in `99-local.yaml.example` to your `99-local.yaml`.
-2. Now, replace `<my_github_username>` with your github username
-3. Fill in any ansible options, examples:
+2. Fill in any ansible options, examples:
    * `foreman_devel_github_push_ssh`: Force git to push over SSH when HTTPS remote is configured
    * `ssh_forward_agent`: Forward local SSH keys to the box via ssh-agent
-   * `katello_devel_github_username`: Your GitHub username to set up repository forks
-4. Fill in any foreman-installer options, examples:
+3. Fill in any foreman-installer options, examples:
    * `--katello-devel-use-ssh-fork`: will add your fork by SSH instead of HTTPS
    * `--katello-devel-fork-remote-name`: will change the naming convention for your fork's remote
    * `--katello-devel-upstream-remote-name`: will change the naming convention for the upstream (non-fork) repositories remote

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -8,7 +8,6 @@ centos7-katello-devel:
     variables:
       ssh_forward_agent: true
       foreman_devel_github_push_ssh: True
-      katello_devel_github_username: <REPLACE ME>
 
 centos8-katello-devel:
   primary: true
@@ -29,8 +28,6 @@ centos7-luna-devel:
   ansible:
     playbook: 'playbooks/luna-devel.yml'
     group: 'devel'
-    variables:
-      katello_devel_github_username: <REPLACE ME>
 
 centos7-luna-demo:
   box: centos7
@@ -45,7 +42,6 @@ centos7-hammer-devel:
     playbook: 'playbooks/hammer_devel.yml'
     group: 'hammer-devel'
     variables: # defaults in roles/hammer_devel/defaults/main.yml
-      hammer_devel_github_username: <REPLACE ME>
       #hammer_devel_server: centos7-katello-devel.custom-domain
 
 katello-remote-execution:
@@ -93,7 +89,6 @@ centos7-dynflow-devel:
     group: 'dynflow_devel'
     playbook: 'playbooks/dynflow_devel.yml'
     variables:
-      dynflow_devel_github_username: '<REPLACE ME>'
       dynflow_devel_github_fork_remote_name: 'origin'
 
 centos7-katello-nightly-stable:


### PR DESCRIPTION
github now requires a password for authenticatd http pulls
which results in an error when the puppet module tries to
fetch from the upstream repo.  We could switch to ssh and
copy the users ssh key to the box, but that seems fraught
with potential security issues