### PR TITLE
pin pulp_installer to 3.15.2-2

### DIFF
--- a/requirements-pulp.yml
+++ b/requirements-pulp.yml
@@ -1,2 +1,3 @@
 collections:
   - name: pulp.pulp_installer
+    version: 3.15.2-2


### PR DESCRIPTION
pulp releases async updates as X.Y.Z-N, but ansible galaxy considers it
to be older than X.Y.Z (like dictated by SemVer)

pin to -2 until 3.15.3 is out