### PR TITLE
[WIP] Install epel repository on CentOS 8 (and Stream)

### DIFF
--- a/roles/foreman_server_repositories/meta/main.yml
+++ b/roles/foreman_server_repositories/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - role: epel_repositories
     when:
       - foreman_server_repositories_epel|bool
-      - ansible_distribution_major_version == '7'
+      - ansible_distribution_major_version > '6'
   - role: ansible_repositories
     when:
     - foreman_server_repositories_ansible|bool


### PR DESCRIPTION
Without epel repository foreman-installer is failing
due to missing 'qpid-proton-c-devel' package