### PR TITLE
Drop Ubuntu 18.04 from nightly

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -102,5 +102,4 @@ installers:
       - 'centos8'
       - 'centos8-stream'
       - 'debian10'
-      - 'ubuntu1804'
       - 'ubuntu2004'


### PR DESCRIPTION
The upcoming Foreman 3.1 will drop Ubuntu 18.04 support.