### PR TITLE
allow downgrades of individual packages when updating OS

### DIFF
--- a/roles/update_os_packages/tasks/main.yml
+++ b/roles/update_os_packages/tasks/main.yml
@@ -3,6 +3,7 @@
   yum:
     name: '*'
     update_cache: yes
+    allow_downgrade: yes
     state: latest
   tags:
     - packages


### PR DESCRIPTION
sometimes it is beneficial to allow to downgrade a package instead of
failing the whole upgrade

This is currently needed on CentOS Stream 8 as the current Stream 8 Vagrant box
('centos/stream8', v20210210.0) contains freetype-2.9.1-5.el8.x86_64 which was
never tagged into dist-c8(-stream) [1], which results in freetype-devel not being
installable without `allow_downgrade`

[1] https://koji.mbox.centos.org/koji/buildinfo?buildID=14760