### PR TITLE
don't try to install rpmdevtools

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -10,8 +10,6 @@ load fixtures/content
 setup() {
   tSetOSVersion
   HOSTNAME=$(hostname -f)
-
-  tCommandExists rpmdev-vercmp || tPackageInstall rpmdevtools
 }
 
 # Ensure we have at least one organization present so that the test organization


### PR DESCRIPTION
we dropped the usage of it in e16a19d7821a4c44e467352e7ad69d1fa59ffa1a,
but didn't drop installing it

Fixes: e16a19d7821a4c44e467352e7ad69d1fa59ffa1a