### PR TITLE
Add a CentOS 9 Stream box

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -36,3 +36,8 @@ boxes:
     scenarios:
       - foreman
       - katello
+
+  centos9-stream:
+    box_name: 'centos/stream9'
+    disk_size: 40
+    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20211203.0.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
Currently centos/stream9 doesn't exist on vagrantup.com but there is a direct link. This allows early work to start while CentOS works on automatically updating vagrantup.com.