### PR TITLE
force hammer cache reload when enabling puppet

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -16,6 +16,8 @@ fi
     skip "Enabling Puppet explicitly is only needed with Katello 4.3+"
   fi
   foreman-installer --enable-foreman-plugin-puppet --enable-foreman-cli-puppet --foreman-proxy-puppet true --foreman-proxy-puppetca true --foreman-proxy-content-puppet true --enable-puppet --puppet-server true --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+  # Force hammer to reload the apidoc cache - https://projects.theforeman.org/issues/28283
+  hammer --reload-cache ping
 }
 
 @test "check smart proxy is registered" {


### PR DESCRIPTION
no idea why/how this worked before, but you need to drop the hammer apidoc cache if you change the apidoc