### PR TITLE
only enable katello module on non-foreman installs

### DIFF
--- a/roles/foreman_installer/tasks/modules.yml
+++ b/roles/foreman_installer/tasks/modules.yml
@@ -30,5 +30,6 @@
     warn: False
     creates: /etc/dnf/modules.d/katello.module
   when:
+    - foreman_installer_scenario != 'foreman'
     - katello_repositories_version is defined
     - katello_repositories_version == "nightly" or katello_repositories_version is version('4.3', '>=')


### PR DESCRIPTION
katello repo version var is always defined in our pipes

Fixes: 4a31dd26e81f7df67de3e26d752c7bfaf32b0f20