### PR TITLE
allow ansible_repositories on other RH family OSes

### DIFF
--- a/roles/ansible_repositories/tasks/main.yml
+++ b/roles/ansible_repositories/tasks/main.yml
@@ -5,4 +5,6 @@
     state: "{{ ansible_repositories_state }}"
   tags:
     - packages
-  when: ansible_distribution == 'CentOS'
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution != 'RedHat'


### PR DESCRIPTION
we need this on Alma and Rocky too