### PR TITLE
only use epel url for RHEL systems

### DIFF
--- a/roles/epel_repositories/defaults/main.yml
+++ b/roles/epel_repositories/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 epel_repositories_state: present
 epel_repositories_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-epel_repositories_name: "{{ epel_repositories_url if epel_repositories_state == 'present' else 'epel-release' }}"
+epel_repositories_name: "{{ epel_repositories_url if (epel_repositories_state == 'present' and ansible_distribution == 'RedHat') else 'epel-release' }}"


### PR DESCRIPTION
all others (CentOS, Alma, Rocky) ship it in their repos already

this fixes the ussue where the URL sometimes returns 403 in our CI