### PR TITLE
Revert "pin chromium to 86.x which works fine -- local RPM copy"

### DIFF
--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -7,8 +7,6 @@ smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
 smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
 smoker_markers:
-# pinned to 86 as 87 hangs randomly: https://bugzilla.redhat.com/show_bug.cgi?id=1914166
 smoker_browser_packages:
-  - https://people.redhat.com/evgeni/chrome86/chromedriver-86.0.4240.193-1.el7.x86_64.rpm
-  - https://people.redhat.com/evgeni/chrome86/chromium-86.0.4240.193-1.el7.x86_64.rpm
-  - https://people.redhat.com/evgeni/chrome86/chromium-common-86.0.4240.193-1.el7.x86_64.rpm
+  - chromium
+  - chromedriver


### PR DESCRIPTION
This reverts commit ef6f01efc6b670bad4cf19f327e135ddbbe93464.

Seems I can't reproduce this anymore \o/

chromium-common-99.0.4844.51-1.fc35.x86_64
chromium-99.0.4844.51-1.fc35.x86_64
chromedriver-99.0.4844.51-1.fc35.x86_64