### PR TITLE
use the right name for the job template based on Foreman version

### DIFF
--- a/bats/fb-test-foreman-rex.bats
+++ b/bats/fb-test-foreman-rex.bats
@@ -3,6 +3,16 @@
 
 set -o pipefail
 
+load os_helper
+load foreman_helper
+
 @test "run 'uptime' via Remote Execution" {
-  hammer job-invocation create --job-template 'Run Command - SSH Default' --inputs 'command=uptime' --search-query "name = $HOSTNAME"
+  FOREMAN_VERSION=$(tForemanVersion)
+  if [[ $FOREMAN_VERSION == 2.* || $FOREMAN_VERSION == 3.[012] ]]; then
+    job_template='Run Command - SSH Default'
+  else
+    job_template='Run Command - Script Default'
+  fi
+
+  hammer job-invocation create --job-template "${job_template}" --inputs 'command=uptime' --search-query "name = $HOSTNAME"
 }


### PR DESCRIPTION
REX 6.1.0 renamed the template to "Script", and that ships in Foreman 3.3+