### PR TITLE
Add Regexp as permitted class for Psych

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/packer/scripts/build_stable_dev_box.rb
+++ b/packer/scripts/build_stable_dev_box.rb
@@ -25,7 +25,7 @@ def find_version(version_string)
   end
 
   version_file =  "#{__dir__}/../../vagrant/config/versions.yaml"
-  versions = YAML.load(File.read(version_file))
+  versions = YAML.load(File.read(version_file), permitted_classes: [Regexp])
 
   versions['installers'].each do |version|
     if version['katello'] == version_string

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -42,7 +42,7 @@ module Forklift
 
     def load_box_file(file)
       file = File.read(file)
-      YAML.load(ERB.new(file).result)
+      YAML.load(ERB.new(file).result, permitted_classes: [Regexp])
     end
 
     def process_boxes!(boxes)

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -33,7 +33,7 @@ module Forklift
     end
 
     def versions
-      YAML.load_file("#{@root_dir}/config/versions.yaml")
+      YAML.load_file("#{@root_dir}/config/versions.yaml", permitted_classes: [Regexp])
     end
 
   end

--- a/vagrant/lib/forklift/settings.rb
+++ b/vagrant/lib/forklift/settings.rb
@@ -7,7 +7,7 @@ module Forklift
 
     def initialize
       settings_file = File.join(__dir__, '..', '..', 'settings.yaml')
-      @settings = File.exist?(settings_file) ? YAML.load_file(settings_file) : {}
+      @settings = File.exist?(settings_file) ? YAML.load_file(settings_file, permitted_classes: [Regexp]) : {}
     end
 
   end


### PR DESCRIPTION
When updating to fedora 36, we get the following error:
```
Vagrant failed to initialize at a very early stage:

There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /home/faguiard/project/pulp_installer/Vagrantfile
Line number: 0
Message: Psych::DisallowedClass: Tried to load unspecified class: Regexp
```

https://stackoverflow.com/questions/71332602/upgrading-to-ruby-3-1-causes-psychdisallowedclass-exception-when-using-yaml-lo