### PR TITLE
always use YAML.safe_load to load YAML

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '2.0'
           - '2.6'
           - '2.7'
           - '3.0'
@@ -53,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install

--- a/packer/scripts/build_stable_dev_box.rb
+++ b/packer/scripts/build_stable_dev_box.rb
@@ -25,7 +25,7 @@ def find_version(version_string)
   end
 
   version_file =  "#{__dir__}/../../vagrant/config/versions.yaml"
-  versions = YAML.load(File.read(version_file))
+  versions = YAML.safe_load(File.read(version_file))
 
   versions['installers'].each do |version|
     if version['katello'] == version_string

--- a/vagrant/Gemfile
+++ b/vagrant/Gemfile
@@ -11,7 +11,11 @@ group :test do
   gem 'minitest'
   gem 'mocha'
   gem 'rake'
-  gem 'rubocop', '<0.50'
+  if RUBY_VERSION < '3.1'
+    # we need a rubocop that still can manage Ruby 2.0 code
+    # but 0.49.x is not compatible with Ruby 3.1
+    gem 'rubocop', '<0.50'
+  end
 end
 
 # rubocop:enable Naming/FileName

--- a/vagrant/Gemfile
+++ b/vagrant/Gemfile
@@ -1,6 +1,10 @@
 # rubocop:disable Naming/FileName
 source 'https://rubygems.org'
 
+if RUBY_VERSION < '2.1'
+  gem 'psych', '~> 2.0'
+end
+
 group :test do
   gem 'deep_merge'
   gem 'json'

--- a/vagrant/Rakefile
+++ b/vagrant/Rakefile
@@ -8,11 +8,15 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
+default_tasks = %i[test]
+
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
+  # insert 0, because Ruby 2.0 doesn't know Array.prepend
+  default_tasks.insert(0, 'rubocop')
 rescue LoadError
   puts 'Rubocop not loaded'
 end
 
-task :default => %i[rubocop test]
+task :default => default_tasks

--- a/vagrant/lib/forklift/box_factory.rb
+++ b/vagrant/lib/forklift/box_factory.rb
@@ -42,7 +42,7 @@ module Forklift
 
     def load_box_file(file)
       file = File.read(file)
-      YAML.load(ERB.new(file).result)
+      YAML.safe_load(ERB.new(file).result, permitted_classes: [Regexp])
     end
 
     def process_boxes!(boxes)

--- a/vagrant/lib/forklift/box_loader.rb
+++ b/vagrant/lib/forklift/box_loader.rb
@@ -33,7 +33,7 @@ module Forklift
     end
 
     def versions
-      YAML.load_file("#{@root_dir}/config/versions.yaml")
+      YAML.safe_load(File.read("#{@root_dir}/config/versions.yaml"))
     end
 
   end

--- a/vagrant/lib/forklift/settings.rb
+++ b/vagrant/lib/forklift/settings.rb
@@ -7,7 +7,7 @@ module Forklift
 
     def initialize
       settings_file = File.join(__dir__, '..', '..', 'settings.yaml')
-      @settings = File.exist?(settings_file) ? YAML.load_file(settings_file) : {}
+      @settings = File.exist?(settings_file) ? YAML.safe_load(File.read(settings_file)) : {}
     end
 
   end


### PR DESCRIPTION
and pass `permitted_classes: [Regexp]` when loading boxes, as we need
regexp when using cloudy backends