### PR TITLE
Suggest --katello-devel-modulestream-nodejs installer arg

### DIFF
--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -23,6 +23,7 @@ centos8-katello-devel:
       katello_repositories_environment: staging
       foreman_installer_options:
         - "--foreman-proxy-content-enable-ostree=true"
+        - "--katello-devel-modulestream-nodejs=12"
 
 
 centos7-luna-devel:


### PR DESCRIPTION
In vagrant/boxes.d/99-local.yaml.example. This allows the user
to specify the nodejs modularity stream to use for EL8+.
Support was added in puppet-katello_devel with
https://github.com/theforeman/puppet-katello_devel/commit/1bd2ba