### PR TITLE
use foreman_repositories from the operations collection

### DIFF
--- a/roles/foreman_repositories/tasks/debian_release_repos.yml
+++ b/roles/foreman_repositories/tasks/debian_release_repos.yml
@@ -1,16 +1,4 @@
 ---
-- name: 'Install Foreman GPG key'
-  get_url:
-    url: https://deb.theforeman.org/foreman.asc
-    dest: /etc/apt/trusted.gpg.d/foreman.asc
-    mode: '0444'
-
 - name: 'Install Foreman {{ foreman_repositories_version }} repository'
-  apt_repository:
-    repo: deb http://deb.theforeman.org {{ ansible_distribution_release }} {{ foreman_repositories_version }}
-    state: present
-
-- name: 'Manage Foreman {{ foreman_repositories_version }} plugins repository'
-  apt_repository:
-    repo: deb http://deb.theforeman.org plugins {{ foreman_repositories_version }}
-    state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"
+  include_role:
+    role: theforeman.operations.foreman_repositories

--- a/roles/foreman_repositories/tasks/redhat_release_repos.yml
+++ b/roles/foreman_repositories/tasks/redhat_release_repos.yml
@@ -1,8 +1,6 @@
 ---
 - name: 'Setup Foreman {{ foreman_repositories_version }} Repository'
-  yum:
-    name: https://yum.theforeman.org/releases/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
-    disable_gpg_check: True
-    state: present
+  include_role:
+    role: theforeman.operations.foreman_repositories
   tags:
     - packages

--- a/roles/katello_repositories/tasks/release_repos.yml
+++ b/roles/katello_repositories/tasks/release_repos.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Setup Katello {{ katello_repositories_version }} Repository'
-  yum:
-    name: https://{{ 'yum.theforeman.org/katello' if (katello_repositories_version == 'nightly' or katello_repositories_version is version('4.1', '>=')) else 'fedorapeople.org/groups/katello/releases/yum' }}/{{ katello_repositories_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm
-    disable_gpg_check: True
-    state: present
+  include_role:
+    role: theforeman.operations.foreman_repositories
+  vars:
+    foreman_repositories_katello_version: "{{ katello_repositories_version }}"


### PR DESCRIPTION
at least for the release repos, it knows what to do, and has all the
nice module enablement stuff in