### PR TITLE
Use 'python3' interpreter specifically

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Adapted from Mark Mandel's implementation
 # https://github.com/ansible/ansible/blob/devel/plugins/inventory/vagrant.py
 import argparse


### PR DESCRIPTION
On distributions without a default 'python' interpreter,
the inventory script will fail to execute properly preventing host matching

Failure was noticed on RHEL8