### PR TITLE
Teach resize_disk about btrfs

### DIFF
--- a/playbooks/resize_disk.yaml
+++ b/playbooks/resize_disk.yaml
@@ -35,3 +35,7 @@
     - name: Grow ext4 filesystem
       command: resize2fs {{ root_partition.stdout.split(' ')[0] }}
       when: '"ext4" in root_partition.stdout'
+
+    - name: Grow btrfs filesystem
+      command: btrfs filesystem resize max /
+      when: '"btrfs" in root_partition.stdout'


### PR DESCRIPTION
Fedora now defaults to btrfs.

Command taken from https://www.thegeekdiary.com/how-to-resize-expand-a-btrfs-volume-filesystem/ and I assume btrfs-progs is already installed if it is mounted.

Untested. @ggainey would you mind testing this?