### PR TITLE
hack around python vs python3 binary names

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env bash
+# this is a very crude hack and can be removed once we have no more python2 systems
+# that need to run this code
+"exec" "$(command -v python3 || command -v python)" "$0" "$@"
 # Adapted from Mark Mandel's implementation
 # https://github.com/ansible/ansible/blob/devel/plugins/inventory/vagrant.py
 import argparse


### PR DESCRIPTION
this is a hack! please remove once we don't need any python2 support
anymore and replace with a python3 shebang