### PR TITLE
Use python 2 and 3 compatible split()

### DIFF
--- a/inventories/vagrant.py
+++ b/inventories/vagrant.py
@@ -79,7 +79,7 @@ def get_ssh_configs(hosts):
         line = line.strip()
         if not line:
             continue
-        key, value = line.split(maxsplit=1)
+        key, value = line.split(None, 1)
         if key == 'Host':
             host = value
         elif host:


### PR DESCRIPTION
Python 2 does not support maxsplit keyword on the split method.
This change can be reverted once our environments are off of EL7
based infra.