### PR TITLE
Skip ostree bats tests if not enabled

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -77,6 +77,7 @@ setup() {
   fi
 
   tSkipIfOlderThan43
+  tSkipUnlessContentType 'ostree'
 
   hammer repository create --organization="${ORGANIZATION}" --url=https://fixtures.pulpproject.org/ostree/small/ \
     --product="${PRODUCT}" --content-type="ostree" --name "${OSTREE_REPOSITORY}" | grep -q "Repository created"
@@ -88,7 +89,8 @@ setup() {
   fi
 
   tSkipIfOlderThan43
-  
+  tSkipUnlessContentType 'ostree'
+
   hammer repository synchronize --organization="${ORGANIZATION}" \
     --product="${PRODUCT}" --name="${OSTREE_REPOSITORY}"
 }
@@ -115,9 +117,10 @@ setup() {
   fi
 
   tSkipIfOlderThan43
+  tSkipUnlessContentType 'ostree'
 
   wget --no-parent -r https://fixtures.pulpproject.org/ostree/small/
-  tDirectoryExists fixtures.pulpproject.org/ostree 
+  tDirectoryExists fixtures.pulpproject.org/ostree
   tar --exclude="index.html" -cvf "fixtures_small_repo.tar" -C fixtures.pulpproject.org/ostree "small"
   hammer repository upload-content --organization="${ORGANIZATION}" --product="${PRODUCT}" --name ${OSTREE_REPOSITORY} --content-type ostree_ref \
       --path fixtures_small_repo.tar --ostree-repository-name small

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -88,3 +88,17 @@ tCheckPulpYumContent() {
   tFileExists ${TEST_RPM_FILE} && rpm -qp ${TEST_RPM_FILE}
   tFileExists ${TEST_RPM_FILE} && rm ${TEST_RPM_FILE}
 }
+
+tHasContentType() {
+  CONTENT_TYPE=$1
+
+  curl https://`hostname`:9090/v2/features --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem | ruby -e "require 'json'; puts JSON.load(ARGF.read).fetch('pulpcore').fetch('capabilities').include?($CONTENT_TYPE)"
+}
+
+tSkipUnlessContentType() {
+  CONTENT_TYPE=$1
+
+  if ! tHasContentType $CONTENT_TYPE; then
+    skip "Content type ${CONTENT_TYPE} is not enabled"
+  fi
+}


### PR DESCRIPTION
While this pattern could be applied more broadly, this is to tackle this specific use case first and then follow ups could organize better and make use of it.