### PR TITLE
Change from Pulp Installer 3.16.0 to 3.15.9

### DIFF
--- a/requirements-pulp.yml
+++ b/requirements-pulp.yml
@@ -1,3 +1,3 @@
 collections:
   - name: pulp.pulp_installer
-    version: 3.16.0
+    version: 3.15.9


### PR DESCRIPTION
Since 3.16 is not receiving updates from Pulp Installer, and 3.15.9 have all the fixes that we want right now.