### PR TITLE
Updating Pulpcore to 3.15.9-1

### DIFF
--- a/requirements-pulp.yml
+++ b/requirements-pulp.yml
@@ -1,3 +1,3 @@
 collections:
   - name: pulp.pulp_installer
-    version: 3.15.9
+    version: 3.15.9-1


### PR DESCRIPTION
With the merge of #1539 we got hit by another issue with the install for EL7, EL8 now is working.

3.15.9-1 brings a fix for [ #pulp_installer/pull/914](https://github.com/pulp/pulp_installer/pull/914) that aims to fix the EL7 install Issue