### PR TITLE
Deal with spaces in content view names

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -160,7 +160,7 @@ setup() {
     --content-view="${CONTENT_VIEW}" --version="1.0"
   export_version_id=$(hammer --output csv --no-headers content-view version show --version="1.0" --content-view="${CONTENT_VIEW}" --organization="${ORGANIZATION}" \
     --fields=id)
-  actual_size=$(du -k $(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path")/*.gz | cut -f 1)
+  actual_size=$(du -k "$(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path")"/*.gz | cut -f 1)
 
  [ $actual_size -ge 40 ]
 }
@@ -214,7 +214,7 @@ setup() {
   hammer content-export complete library --organization="${ORGANIZATION}"
   export_version_id=$(hammer --output csv --no-headers content-view version list --content-view="${LIBRARY}" --organization="${ORGANIZATION}" \
     --fields=id --per-page=1 --order="version DESC")
-  actual_size=$(du -k $(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path")/*.gz | cut -f 1)
+  actual_size=$(du -k "$(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path")"/*.gz | cut -f 1)
 
   [ $actual_size -ge 40 ]
 }
@@ -268,7 +268,7 @@ setup() {
 
   hammer content-export incremental version --organization="${ORGANIZATION}" \
     --content-view="${CONTENT_VIEW}" --id="$export_version_id"
-  actual_size=$(du -k $(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path" --per-page=1)/*.gz  | cut -f 1)
+  actual_size=$(du -k "$(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path" --per-page=1)"/*.gz  | cut -f 1)
   # actual size of export should be less than 14K
   [ $actual_size -le 14 ]
 }
@@ -280,7 +280,7 @@ setup() {
   export_version_id=$(hammer --output csv --no-headers content-view version list --content-view="${LIBRARY}" --organization="${ORGANIZATION}" \
     --fields=id --per-page=1 --order="version DESC")
 
-  actual_size=$(du -k $(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path"  --per-page=1)/*.gz | cut -f 1)
+  actual_size=$(du -k "$(hammer --output csv --no-headers content-export list --content-view-version-id=$export_version_id --fields="path"  --per-page=1)"/*.gz | cut -f 1)
 
   [ $actual_size -le 14 ]
 }


### PR DESCRIPTION
Output from a test run:

	# Generated /var/lib/pulp/exports/Test_Organization/Test CV/1.0/2022-08-03T00-17-11-00-00/metadata.json
	# du: cannot access '/var/lib/pulp/exports/Test_Organization/Test': No such file or directory
	# du: cannot access 'CV/1.0/2022-08-03T00-17-11-00-00/*.gz': No such file or directory

By quoting the path before expansion lets bash handle the spaces in
filenames.