### PR TITLE
Install telemetry dependencies using pip3.8

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -31,16 +31,6 @@
           - rubygem-deep_merge
         state: 'present'
 
-    - name: 'install telemetry system dependencies'
-      package:
-        name:
-          - python3-devel
-          - redhat-rpm-config
-        state: 'present'
-      when:
-        - forklift_telemetry|default(false)
-        - ansible_distribution_major_version != '7'
-
     - name: 'install telemetry dependencies'
       pip:
         name:
@@ -48,6 +38,7 @@
           - opentelemetry-api
           - opentelemetry-sdk
           - opentelemetry-exporter-otlp
+        executable: pip3.8
       when:
         - forklift_telemetry|default(false)
         - ansible_distribution_major_version != '7'


### PR DESCRIPTION
Ansible runs under Python 3.8 so the dependencies should also be installed under it, rather than the platform Python. This also means wheels can be used, which speeds up installation greatly.

Fixes: dfd0fa34134c4b7e70d0b5c485dc053a9a123f8e