### PR TITLE
Remove attach subscription to AK test since orgs are in SCA by default

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -297,6 +297,8 @@ setup() {
 }
 
 @test "add subscription to activation key" {
+  tSkipIfNewerthan45
+
   sleep 10
   activation_key_id=$(hammer --csv --no-headers activation-key info --organization="${ORGANIZATION}" \
     --name="${ACTIVATION_KEY}" | cut -d, -f2)

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -42,6 +42,13 @@ tSkipIfOlderThan43() {
   fi
 }
 
+tSkipIfNewerThan45() {
+  KATELLO_VERSION=$(tKatelloVersion)
+  if [[ $KATELLO_VERSION > 4.5 ]]; then
+    skip "Skip if Katello is newer than 4.5"
+  fi
+}
+
 tSkipIfPulp3Only() {
   KATELLO_VERSION=$(tKatelloVersion)
   if [[ $KATELLO_VERSION == 4.* ]]; then


### PR DESCRIPTION
Since the new Candlepin 4.2 is tagged into nightly, by default orgs are in SCA mode. This means that you can not attach a subscription to an activation key anymore. 

After discussion with @parthaa and @jeremylenz it was decided since entitlement mode is being depreciated and eventually removed, that removing this test is fine.