### PR TITLE
Allow specifying custom user and group in devel scenario

### DIFF
--- a/roles/foreman_installer_devel_scenario/defaults/main.yml
+++ b/roles/foreman_installer_devel_scenario/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 foreman_installer_devel_scenario_modules: /usr/share/foreman-installer/modules
 foreman_installer_devel_scenario_user: vagrant
-foreman_installer_devel_scenario_group: vagrant

--- a/roles/foreman_installer_devel_scenario/defaults/main.yml
+++ b/roles/foreman_installer_devel_scenario/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 foreman_installer_devel_scenario_modules: /usr/share/foreman-installer/modules
+foreman_installer_devel_scenario_user: vagrant
+foreman_installer_devel_scenario_group: vagrant

--- a/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
@@ -1,11 +1,11 @@
 ---
 certs:
-  group: vagrant
+  group: {{ foreman_installer_devel_scenario_group }}
   deploy: true
   generate: true
 katello_devel:
-  deployment_dir: /home/vagrant
-  user: vagrant
+  deployment_dir: /home/{{ foreman_installer_devel_scenario_user }}
+  user: {{ foreman_installer_devel_scenario_user }}
 foreman_proxy_content:
   enable_katello_agent: true
   proxy_pulp_yum_to_pulpcore: true

--- a/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
@@ -1,6 +1,6 @@
 ---
 certs:
-  group: {{ foreman_installer_devel_scenario_group }}
+  group: {{ foreman_installer_devel_scenario_group | default(foreman_installer_devel_scenario_user) }}
   deploy: true
   generate: true
 katello_devel:

--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -11,6 +11,8 @@ dependencies:
   - role: postgresql_scl
     when: ansible_distribution_major_version == "7"
   - role: foreman_installer_devel_scenario
+    foreman_installer_devel_scenario_user: "{{ katello_devel_user | default(omit) }}"
+    foreman_installer_devel_scenario_group: "{{ katello_devel_group | default(omit) }}"
   - role: foreman_installer
     foreman_installer_scenario: katello-devel
     foreman_installer_additional_packages:


### PR DESCRIPTION
puppet-katello_devel supports these options but passing them as installer args doesn't set the certs::group parameter. this approach creates a working installation by also properly setting certs::group so that it is inherited by the apache certificate.