### PR TITLE
don't run n-1 tests for foreman scenario

### DIFF
--- a/pipelines/upgrade/08-tests.yaml
+++ b/pipelines/upgrade/08-tests.yaml
@@ -26,3 +26,4 @@
     - role: foreman_testing
       when:
         - forklift_upgrade_version_final == 'nightly' or forklift_upgrade_version_final is version('4.1', '>=')
+        - pipeline_type != 'foreman'


### PR DESCRIPTION
when testing foreman, we do not deploy an external proxy, so there is no n-1 to test