### PR TITLE
correct spelling of tSkipIfNewerThan45

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -297,7 +297,7 @@ setup() {
 }
 
 @test "add subscription to activation key" {
-  tSkipIfNewerthan45
+  tSkipIfNewerThan45
 
   sleep 10
   activation_key_id=$(hammer --csv --no-headers activation-key info --organization="${ORGANIZATION}" \


### PR DESCRIPTION
Fixes: 0753db111d5c5262c17db240485925f8b8730c63