### PR TITLE
Allow setting ansible provisioner config file per box

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -198,6 +198,7 @@ module Forklift
           ansible_provisioner.verbose = ansible['verbose'] || false
           ansible_provisioner.galaxy_role_file = ansible['galaxy_role_file'] if ansible['galaxy_role_file']
           ansible_provisioner.inventory_path = ansible['inventory_path'] if ansible['inventory_path']
+          ansible_provisioner.config_file = ansible['config_file'] if ansible['config_file']
         end
       end
     end


### PR DESCRIPTION
Sometimes it is useful to pass a different Ansible configuration
file for some boxes only, and Vagrant allows us to do so. This
commit exposes that setting in the box definition for Forklift.
If not explicitly specified, the Ansible provisioner will follow
the current default behavior of allowing Ansible to choose its
configuration file via its normal order of precedence, selecting
the ansible.cfg file local to this repository.