### PR TITLE
Stop enabling Ruby 2.7 on Foreman 3.2+

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 collections:
-  - theforeman.operations
+  - name: theforeman.operations
+    version: '>=1.2.3'
+
   - community.general

--- a/roles/foreman_installer/tasks/modules.yml
+++ b/roles/foreman_installer/tasks/modules.yml
@@ -5,7 +5,6 @@
     state: present
   when:
     - foreman_repositories_version is defined
-    - foreman_repositories_version == "nightly" or foreman_repositories_version is version('2.5', '>=')
-    # Foreman 3.2+ *shouldn't* need this, but enable the foreman:el8 module instead
-    # However, not all of our infra is prepared to do this yet
-    #- foreman_repositories_version is version('3.1', '<=')
+    - foreman_repositories_version != "nightly"
+    - foreman_repositories_version is version('2.5', '>=')
+    - foreman_repositories_version is version('3.1', '<=')


### PR DESCRIPTION
Modular metadata is now available. The foreman_repositories role should enable the right modules now. Users should be sure to install at least version 1.2.3.