### PR TITLE
force short domain

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -23,6 +23,7 @@
       boxes:
         exclude:
           - '^[^p]'
+      domain: example.com
   tasks:
     - name: 'Install Forklift dependencies'
       package:


### PR DESCRIPTION
Sometimes our CI runs on nodes that have longer hostnames
(like `n27-20-11.pool.ci.centos.org`) that result in
`#{hostname-s.strip.downcase}.example.com` being to long when combined
with the rather long pipeline hostnames (hostnames are limited to 65
characters).

Use `example.com` as the domain for tests in CI, which should be
sufficiently short.