### PR TITLE
don't pass `some_var|default(omit)` to roles

### DIFF
--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -11,8 +11,6 @@ dependencies:
   - role: postgresql_scl
     when: ansible_distribution_major_version == "7"
   - role: foreman_installer_devel_scenario
-    foreman_installer_devel_scenario_user: "{{ katello_devel_user | default(omit) }}"
-    foreman_installer_devel_scenario_group: "{{ katello_devel_group | default(omit) }}"
   - role: foreman_installer
     foreman_installer_scenario: katello-devel
     foreman_installer_additional_packages:


### PR DESCRIPTION
`omit` only works for modules as they have special code to filter this out, but not for roles. Omit (hah!) passing `omit` in katello_devel and make the user set `foreman_installer_devel_scenario_user` as they require themself.

Otherwise you get errors like `Could not create user __omit_place_holder__67702be7f0289f0f990ab1ec3b121327f51b2d5f` when not setting the variable.

Fixes: 06ffd5ebeaaf9c0cc639e8ec2218a39bbd1ff65d