### PR TITLE
Update Vagrant installation instructions

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -2,10 +2,10 @@
 
 ## Fedora
 
-Assuming you want vagrant with libvirt:
+Assuming you want Vagrant with libvirt:
 
 ```bash
-dnf -y install libvirt-daemon-kvm ansible vagrant-libvirt
+dnf -y install libvirt-daemon-kvm vagrant-libvirt
 systemctl enable --now libvirtd
 ```
 Add your user to the libvirt group to avoid password prompts on running vagrant commands with libvirt provider:
@@ -15,26 +15,12 @@ sudo gpasswd -a ${USER} libvirt
 newgrp libvirt
 ```
 
-## Centos 7
+## CentOS Stream 8 / 9
 
-For this you need EPEL and Vagrant RPM
-
+Enable COPR repositories:
 ```bash
-yum -y install epel-release centos-release-scl
-yum -y install libvirt-daemon-kvm ansible https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.rpm
-systemctl enable libvirtd
-systemctl start libvirtd
+dnf -y copr enable pvalena/rubygems
+dnf -y copr enable pvalena/vagrant
 ```
 
-Now you need to ensure your user can access vagrant and libvirt:
-
-```bash
-usermod --append --groups libvirt `whoami`
-```
-
-Install vagrant libvirt plugin:
-
-```bash
-sudo yum -y install libxslt-devel libxml2-devel libvirt-devel libguestfs-tools-c ruby-devel gcc
-vagrant plugin install vagrant-libvirt
-```
+Now follow the Fedora instructions.


### PR DESCRIPTION
This drops the CentOS 7 instructions since that's too old.