### PR TITLE
Update rpm packaging box to F36 and include semver + missing pkgs

### DIFF
--- a/playbooks/rpm_packaging.yml
+++ b/playbooks/rpm_packaging.yml
@@ -18,17 +18,21 @@
           - ruby-devel
           - curl-devel
           - gem
-          - python3-click
           - python3-ruamel-yaml
-          - crudini
           - tito
           - mock
+          - jq
+          - python3-pip
+          - wget
+          - vim
+          - python3-semver
       become: true
 
     - name: Install obal
       pip:
         name: obal
         state: present
+        executable: pip3
       become: true
 
     - name: Clone foreman-packaging

--- a/vagrant/boxes.d/03-packaging.yaml
+++ b/vagrant/boxes.d/03-packaging.yaml
@@ -1,6 +1,6 @@
 ---
 rpm-packaging:
-  box: fedora33
+  box: fedora36
   ansible:
     playbook: 'playbooks/rpm_packaging.yml'
     variables:

--- a/vagrant/test/lib/box_loader_test.rb
+++ b/vagrant/test/lib/box_loader_test.rb
@@ -25,7 +25,7 @@ class TestBoxLoader < Minitest::Test
     assert_instance_of Hash, loader.boxes
     assert_includes loader.boxes, 'rpm-packaging'
     assert_equal 'rpm-packaging', loader.boxes['rpm-packaging']['name']
-    assert_equal 'fedora/33-cloud-base', loader.boxes['rpm-packaging']['box_name']
+    assert_equal 'fedora/36-cloud-base', loader.boxes['rpm-packaging']['box_name']
   end
 
   private


### PR DESCRIPTION
* Update the box to use Fedora 36 since 33 is no longer present to be downloaded
* When using the `bump_rpm` script I noticed that it failed with missing `jq` and python `semver`
* Updated the playbook to include those 2 packages and use `python3-pip`
* Added `vim` and `wget` since those are handy

Python traceback is as follows:
```python
Traceback (most recent call last):
  File "/home/vagrant/foreman-packaging/update-requirements", line 8, in <module>
    import semver
ModuleNotFoundError: No module named 'semver'
```
Results of spinup:

```bash
PLAY RECAP *********************************************************************
rpm-packaging              : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

* Let me know if you want a better commit message, for the extra packages side
* Created this pr with the new setup, script works well with F36 https://github.com/theforeman/foreman-packaging/pull/8542