### PR TITLE
place bats and sos results in correctly named folders

### DIFF
--- a/pipelines/vars/install_base.yml
+++ b/pipelines/vars/install_base.yml
@@ -1,3 +1,4 @@
+pipeline_action: install
 forklift_name: "pipe-{{ pipeline_type }}-{{ pipeline_version }}-{{ pipeline_os }}"
 forklift_server_name: "pipe-{{ pipeline_type }}-server-{{ pipeline_version }}-{{ pipeline_os }}"
 forklift_proxy_name: "pipe-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ pipeline_os }}"

--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -1,3 +1,4 @@
+pipeline_action: upgrade
 forklift_name: "pipe-upgrade-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_server_name: "pipe-up-{{ pipeline_type }}-{{ pipeline_version}}-{{ pipeline_os }}"
 forklift_proxy_name: "pipe-up-{{ pipeline_type }}-proxy-{{ pipeline_version}}-{{ pipeline_os }}"

--- a/playbooks/collect_debug.yml
+++ b/playbooks/collect_debug.yml
@@ -3,7 +3,7 @@
   become: true
   vars:
     bats_output_dir: '/root/bats_results'
-    remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
+    remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}-{{ pipeline_action | default('install') }}"
     smoker_output_dir: '/home/vagrant/smoker'
     backup_output_dir: '/var/tmp/foreman-backup'
   roles:

--- a/roles/bats/defaults/main.yml
+++ b/roles/bats/defaults/main.yml
@@ -6,7 +6,7 @@ bats_forklift_dir: "/root/forklift"
 bats_forklift_repo: "https://github.com/theforeman/forklift.git"
 bats_forklift_version: HEAD
 bats_output_dir: "/root/bats_results"
-bats_remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
+bats_remote_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}-{{ pipeline_action | default('install') }}"
 bats_update_forklift: "yes"
 bats_run: true
 bats_setup: []

--- a/roles/sos_report/defaults/main.yml
+++ b/roles/sos_report/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 sosreport_fetch: true
 sosreport_output_dir: '/root'
-sosreport_local_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}"
+sosreport_local_dir: "/tmp/debug-{{ pipeline_type | default('foreman') }}-{{ pipeline_version | default('nightly') }}-{{ pipeline_os | default('el7') }}-{{ pipeline_action | default('install') }}"


### PR DESCRIPTION
before this change, these folders didn't include whether it's a instal or upgrade pipe. this wasn't a problem as we were running one pipe per box, but now we are running multiple and things break