### PR TITLE
Allow install of Koji on EL8 from Epel

### DIFF
--- a/roles/koji/tasks/download.yml
+++ b/roles/koji/tasks/download.yml
@@ -1,8 +1,18 @@
 ---
+- name: 'Install epel-release'
+  yum:
+    name: 'epel-release'
+    state: 'present'
+
 - name: 'Install koji package'
   yum:
     name: 'koji'
     state: 'present'
+
+- name: 'Remove epel-release'
+  yum:
+    name: 'epel-release'
+    state: 'absent'
 
 - name: 'Make repo directory'
   file:


### PR DESCRIPTION
Since we do not support EPEL on the actual install, we enable, install and then remove it. I am running into an issue that I think has to do with Ansible + Python pathing?

```
failed: [pipe-katello-proxy-nightly-centos8-stream] (item=534950) => changed=true 
  ansible_loop_var: item
  cmd:
  - koji
  - --server
  - http://koji.katello.org/kojihub
  - --topurl
  - http://koji.katello.org/kojifiles
  - download-task
  - '534950'
  delta: '0:00:00.065180'
  end: '2022-09-30 13:42:49.119221'
  item: 534950
  msg: non-zero return code
  rc: 1
  start: '2022-09-30 13:42:49.054041'
  stderr: |-
    Traceback (most recent call last):
      File "/bin/koji", line 39, in <module>
        import koji
    ModuleNotFoundError: No module named 'koji'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```

If SSHing on to the box itself, the command works.