### PR TITLE
Always use graphics on Debian 11

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -271,6 +271,8 @@ module Forklift
         add_disks(box, p)
 
         merged_options(box, 'libvirt_options').each do |opt, val|
+          # Debian 11 fails to boot without graphics
+          next if opt == 'graphics_type' && box['box_name'] == 'debian/bullseye64'
           p.instance_variable_set("@#{opt}", val)
         end
       end


### PR DESCRIPTION
Since 6f58dc045513d7091a4d1f0fa75c470208bd05c9 boxes in CI are provisioned without graphics. This was done because multiple users tried to allocate the same port for VNC. However, Debian 11 fails to boot up and fails with a timeout. This ignores the graphics_type option for Debian. This should be OK since Debian 11 only runs under a single user, so it can safely use ports for VNC. No other user will try to allocate the same ports.

Fixes: 6f58dc045513d7091a4d1f0fa75c470208bd05c9