### PR TITLE
pass a fake video device to qemu, even if we disable graphics

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -20,6 +20,9 @@
       libvirt_options:
         volume_cache: unsafe
         graphics_type: none
+        qemu_args:
+          - :value: '-device'
+          - :value: 'cirrus-vga,id=video0'
       boxes:
         exclude:
           - '^[^p]'

--- a/vagrant/lib/forklift/settings.rb
+++ b/vagrant/lib/forklift/settings.rb
@@ -7,7 +7,15 @@ module Forklift
 
     def initialize
       settings_file = File.join(__dir__, '..', '..', 'settings.yaml')
-      @settings = File.exist?(settings_file) ? YAML.safe_load(File.read(settings_file)) : {}
+      @settings = if File.exist?(settings_file)
+                    if Gem::Version.new(Psych::VERSION) < Gem::Version.new('4.0')
+                      YAML.safe_load(File.read(settings_file), [:Symbol])
+                    else
+                      YAML.safe_load(File.read(settings_file), permitted_classes: [:Symbol])
+                    end
+                  else
+                    {}
+                  end
     end
 
   end


### PR DESCRIPTION
this is needed to make Debian 11 boot properly,
see https://bugs.debian.org/1021298 for details