### PR TITLE
Add foreman_repositories_version to the proxy development playbook

### DIFF
--- a/playbooks/foreman_proxy_content_dev.yml
+++ b/playbooks/foreman_proxy_content_dev.yml
@@ -6,6 +6,7 @@
     foreman_proxy_content_server: "{{ groups[foreman_proxy_content_server_group][0] }}"
     foreman_server_repositories_katello: true
     katello_repositories_version: nightly
+    foreman_repositories_version: nightly
   roles:
     - foreman_server_repositories
     - etc_hosts


### PR DESCRIPTION
The proxy devel playbook has recently been complaining about the foreman repositories variable being undefined. This fixes that.