### PR TITLE
Remove abrt and chef plugins from katello-devel-answers.yaml

### DIFF
--- a/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
+++ b/roles/foreman_installer_devel_scenario/templates/katello-devel-answers.yaml
@@ -23,9 +23,7 @@ foreman_proxy:
   puppet: false
   puppetca: false
 puppet: false
-foreman_proxy::plugin::abrt: false
 foreman_proxy::plugin::ansible: false
-foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false


### PR DESCRIPTION
These were dropped from puppet-foreman_proxy with
https://github.com/theforeman/puppet-foreman_proxy/pull/789