### PR TITLE
Don't test Ruby 2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.0'
           - '2.6'
           - '2.7'
           - '3.0'


### PR DESCRIPTION
Ruby 2.0 is very old at this point and tests are failing with `Gem::InstallError: rake requires Ruby version >= 2.2.`

Even Ruby 2.6 is EOL now so we could remove this as well (but it's not currently causing test failures)