### PR TITLE
use pip3.9 now that containers were updated to el8.7

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -45,7 +45,7 @@
           - opentelemetry-api
           - opentelemetry-sdk
           - opentelemetry-exporter-otlp
-        executable: pip3.8
+        executable: pip3.9
       when:
         - forklift_telemetry|default(false)
         - ansible_distribution_major_version != '7'


### PR DESCRIPTION
this contains ansible-core 2.13, which uses python 3.9