### PR TITLE
verify-packages: drop pre Foreman 2.5 support

### DIFF
--- a/bats/fb-verify-packages.bats
+++ b/bats/fb-verify-packages.bats
@@ -6,50 +6,12 @@ set -o pipefail
 load os_helper
 load foreman_helper
 
-@test "verify no rh-ruby24, tfm-ror51 or tfm-ror52 SCL packages" {
-  tSetOSVersion
+@test "verify no rh-ruby24, rh-ruby25, tfm-ror51 or tfm-ror52 SCL packages" {
   if ! tIsRHEL 7; then
     skip "SCL package checks only applicable on EL 7 systems"
   fi
 
-  FOREMAN_VERSION=$(tForemanVersion)
-  if [[ $FOREMAN_VERSION != 2.* ]]; then
-    skip "Verification of no rh-ruby24, tfm-ror51 or tfm-ror52 packages only applies to Foreman 2.*"
-  fi
-
-  if rpm --query --all | grep --quiet --extended-regexp 'rh-ruby24|tfm-ror51|tfm-ror52'; then
-    exit 1
-  fi
-}
-
-@test "verify no rh-ruby25 SCL packages in Foreman 2.5" {
-  tSetOSVersion
-  if ! tIsRHEL 7; then
-    skip "SCL package checks only applicable on EL 7 systems"
-  fi
-
-  FOREMAN_VERSION=$(tForemanVersion)
-  if [[ $FOREMAN_VERSION != 2.[5-9]* && $FOREMAN_VERSION != 3.* ]]; then
-    skip "Verification of no rh-ruby25 packages only applies to Foreman 2.5+"
-  fi
-
-  if rpm --query --all | grep --quiet --extended-regexp 'rh-ruby25'; then
-    exit 1
-  fi
-}
-
-@test "verify no rh-ruby27 SCL packages before Foreman 2.5" {
-  tSetOSVersion
-  if ! tIsRHEL 7; then
-    skip "SCL package checks only applicable on EL 7 systems"
-  fi
-
-  FOREMAN_VERSION=$(tForemanVersion)
-  if [[ $FOREMAN_VERSION != 2.[0-4]* ]]; then
-    skip "Verification of no rh-ruby27 packages only applies to Foreman <= 2.4"
-  fi
-
-  if rpm --query --all | grep --quiet --extended-regexp 'rh-ruby27'; then
+  if rpm --query --all | grep --quiet --extended-regexp 'rh-ruby24|rh-ruby25|tfm-ror51|tfm-ror52'; then
     exit 1
   fi
 }


### PR DESCRIPTION
2.5+ is Ruby 2.7 only on EL7, so we can simplify the test quite a lot