### PR TITLE
don't run kch test by default

### DIFF
--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -16,6 +16,7 @@ server_box:
       bats_tests_additional:
         - fb-katello-proxy.bats
         - "{{ 'fb-katello-client-global-registration.bats' if pipeline_version == 'nightly' or pipeline_version is version('4.1', '>=') else '' }}"
+        - "{{ 'fb-test-katello-change-hostname.bats' if pipeline_action == 'install' else ''}}"
       pipeline_remove_pulp2: true
 proxy_box:
   box: "{{ pipeline_os }}"

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -49,6 +49,7 @@ server_box:
         - "fb-test-foreman-ansible.bats"
         - "fb-test-foreman-templates.bats"
         - "fb-katello-proxy.bats"
+        - "{{ 'fb-test-katello-change-hostname.bats' if pipeline_action == 'install' else ''}}"
       pipeline_remove_pulp2: true
 proxy_box:
   box: "{{ pipeline_os }}"

--- a/roles/bats/defaults/main.yml
+++ b/roles/bats/defaults/main.yml
@@ -18,7 +18,6 @@ bats_tests:
   - "fb-katello-client.bats"
   - "fb-test-puppet.bats"
   - "fb-test-backup.bats"
-  - "fb-test-katello-change-hostname.bats"
 bats_tests_additional: []
 bats_teardown:
   - "fb-destroy-organization.bats"


### PR DESCRIPTION
run it *after* the proxy tests, as otherwise those fail without further changes to the proxy (it needs to know the new name of the katello system)

also run it for install pipelines only, as otherwise the N-1 test will again break the proxy setup as described above