### PR TITLE
run fb-katello-client-global-registration.bats by default

### DIFF
--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -15,7 +15,6 @@ server_box:
         - "{{ '--foreman-proxy-content-enable-ostree true' if (pipeline_os != 'centos7' and (pipeline_version == 'nightly' or pipeline_version is version('4.3', '>='))) else '' }}"
       bats_tests_additional:
         - fb-katello-proxy.bats
-        - "{{ 'fb-katello-client-global-registration.bats' if pipeline_version == 'nightly' or pipeline_version is version('4.1', '>=') else '' }}"
         - "{{ 'fb-test-katello-change-hostname.bats' if pipeline_action == 'install' else ''}}"
       pipeline_remove_pulp2: true
 proxy_box:

--- a/roles/bats/defaults/main.yml
+++ b/roles/bats/defaults/main.yml
@@ -16,6 +16,7 @@ bats_tests:
   - "fb-test-katello.bats"
   - "fb-katello-content.bats"
   - "fb-katello-client.bats"
+  - "fb-katello-client-global-registration.bats"
   - "fb-test-puppet.bats"
   - "fb-test-backup.bats"
 bats_tests_additional: []


### PR DESCRIPTION
It's present since Katello 4.1 which is "old"