### PR TITLE
force execution of REX tests in an own organization

### DIFF
--- a/bats/fb-test-foreman-rex.bats
+++ b/bats/fb-test-foreman-rex.bats
@@ -14,5 +14,12 @@ load foreman_helper
     job_template='Run Command - Script Default'
   fi
 
+  # Force execution of the test in an own Organization
+  # This ensures any *other* proxy with the REX capability is not used,
+  # as that can lead to wrong results.
+  REX_ORG="Remote Execution Org $$"
+  hammer organization create --name "${REX_ORG}"
+  hammer host update --name $HOSTNAME --new-organization "${REX_ORG}"
+
   hammer job-invocation create --job-template "${job_template}" --inputs 'command=uptime' --search-query "name = $HOSTNAME"
 }


### PR DESCRIPTION
This ensures any *other* proxy with the REX capability is not used, as that can lead to wrong results.