### PR TITLE
explicitly set org for the proxy too

### DIFF
--- a/bats/fb-test-foreman-rex.bats
+++ b/bats/fb-test-foreman-rex.bats
@@ -17,9 +17,11 @@ load foreman_helper
   # Force execution of the test in an own Organization
   # This ensures any *other* proxy with the REX capability is not used,
   # as that can lead to wrong results.
+  OLD_ORGS=$(hammer --output csv --no-headers --show-ids proxy info --name $HOSTNAME --fields Organizations)
   REX_ORG="Remote Execution Org $$"
   hammer organization create --name "${REX_ORG}"
   hammer host update --name $HOSTNAME --new-organization "${REX_ORG}"
+  hammer proxy update --name $HOSTNAME --organizations "${OLD_ORGS},${REX_ORG}"
 
   hammer job-invocation create --job-template "${job_template}" --inputs 'command=uptime' --search-query "name = $HOSTNAME"
 }


### PR DESCRIPTION
Katello does this automatically, but not plain Foreman

Fixes: 39c0457ad3c8c133e220fc7c99115182753801fe