### PR TITLE
Enable SELinux test for Foreman and Plugins pipes

### DIFF
--- a/pipelines/vars/forklift_foreman.yml
+++ b/pipelines/vars/forklift_foreman.yml
@@ -13,6 +13,7 @@ server_box:
         - "fb-test-foreman.bats"
         - "fb-test-puppet.bats"
         - "fb-test-backup.bats"
+        - "fb-verify-selinux.bats"
       bats_teardown: []
 forklift_boxes:
   "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"

--- a/pipelines/vars/forklift_plugins.yml
+++ b/pipelines/vars/forklift_plugins.yml
@@ -33,6 +33,7 @@ server_box:
         - "fb-test-foreman-rex.bats"
         - "fb-test-foreman-ansible.bats"
         - "fb-test-foreman-templates.bats"
+        - "fb-verify-selinux.bats"
       bats_teardown: []
 forklift_boxes:
   "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"


### PR DESCRIPTION
These pass fine, it's only Katello that still has issues