### PR TITLE
Use the FQDN for the REX Smart Proxy name

### DIFF
--- a/bats/fb-test-foreman-rex.bats
+++ b/bats/fb-test-foreman-rex.bats
@@ -14,14 +14,16 @@ load foreman_helper
     job_template='Run Command - Script Default'
   fi
 
+  SMART_PROXY_NAME=$(hostname -f)
+
   # Force execution of the test in an own Organization
   # This ensures any *other* proxy with the REX capability is not used,
   # as that can lead to wrong results.
-  OLD_ORGS=$(hammer --output csv --no-headers --show-ids proxy info --name $HOSTNAME --fields Organizations)
+  OLD_ORGS=$(hammer --output csv --no-headers --show-ids proxy info --name $SMART_PROXY_NAME --fields Organizations)
   REX_ORG="Remote Execution Org $$"
   hammer organization create --name "${REX_ORG}"
-  hammer host update --name $HOSTNAME --new-organization "${REX_ORG}"
-  hammer proxy update --name $HOSTNAME --organizations "${OLD_ORGS},${REX_ORG}"
+  hammer host update --name $SMART_PROXY_NAME --new-organization "${REX_ORG}"
+  hammer proxy update --name $SMART_PROXY_NAME --organizations "${OLD_ORGS},${REX_ORG}"
 
-  hammer job-invocation create --job-template "${job_template}" --inputs 'command=uptime' --search-query "name = $HOSTNAME"
+  hammer job-invocation create --job-template "${job_template}" --inputs 'command=uptime' --search-query "name = $SMART_PROXY_NAME"
 }


### PR DESCRIPTION
On Debian the hostname is usually the short name, not the FQDN like on Red Hat based systems. In Foreman the Smart Proxy is registered using the FQDN so no Smart Proxy is found.

This was found via https://community.theforeman.org/t/foreman-plugins-3-5-deb-test-pipeline-3-failed/31619 (https://ci.theforeman.org/job/foreman-plugins-3.5-deb-test-pipeline/3/) and we likely didn't find it because https://ci.theforeman.org/job/foreman-plugins-nightly-deb-test-pipeline/ hadn't ran since March. I just kicked that off, but I expect it to fail in the same way as 3.5.

Fixes: 13630ab2476fda158a55f0d395177e63c2c42306