### PR TITLE
wait for any maybe running puppet agents

### DIFF
--- a/bats/fb-test-puppet.bats
+++ b/bats/fb-test-puppet.bats
@@ -50,6 +50,11 @@ fi
 }
 
 @test "wake up puppet agent" {
+  local next_wait_time=0
+  until [ ! -f /opt/puppetlabs/puppet/cache/state/agent_catalog_run.lock -o $next_wait_time -eq 12 ]; do
+    sleep $(( next_wait_time++ ))
+  done
+
   puppet agent -t -v
 }
 


### PR DESCRIPTION
sometimes there is already a puppet run happening, leading to `puppet agent -t -v` failing with

    Notice: Run of Puppet configuration client already in progress; skipping  (/opt/puppetlabs/puppet/cache/state/agent_catalog_run.lock exists)

Let's be nice and wait for that one to complete before we execute ours.