### PR TITLE
correctly wait for tasks to be completed

### DIFF
--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -145,7 +145,7 @@ tScenario() {
 tWaitForTask() {
   local TASK_LABEL=$1
   local next_wait_time=0
-  while hammer --no-headers task list --search="label=${TASK_LABEL} state=running" | grep "${TASK_LABEL}"; do
+  while [[ $(hammer --no-headers task list --search="label=${TASK_LABEL} state != stopped" | wc -l) -ne 0 ]]; do
     if [[ $next_wait_time -eq 12 ]]; then
       break
     fi


### PR DESCRIPTION
1. check for `state != stopped` so that also planning and pending states are considered
2. use `$(… | wc -l) -ne 0` as not all tasks have their label in the output

Fixes: acb404b0d936279fe49b15ffe20d1bb90bbed539