### PR TITLE
Quote content type in Ruby

### DIFF
--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -99,7 +99,7 @@ tCheckPulpYumContent() {
 tHasContentType() {
   CONTENT_TYPE=$1
 
-  curl https://`hostname`:9090/v2/features --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem | ruby -e "require 'json'; puts JSON.load(ARGF.read).fetch('pulpcore').fetch('capabilities').include?($CONTENT_TYPE)"
+  curl "https://$(hostname):9090/v2/features" --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem | ruby -e "require 'json'; puts JSON.load(ARGF.read).fetch('pulpcore').fetch('capabilities').include?('${CONTENT_TYPE}')"
 }
 
 tSkipUnlessContentType() {


### PR DESCRIPTION
Otherwise you get an Ruby error and the content type detection never works:

    -e:1:in `<main>': undefined local variable or method `ostree' for main:Object (NameError)
    Content type ostree is not enabled

Fixes: 36bec298