### PR TITLE
use ansible_host not ansible_nodename to access foreman in pipelines

### DIFF
--- a/pipelines/install/06-smoker.yml
+++ b/pipelines/install/06-smoker.yml
@@ -5,7 +5,7 @@
   vars_files:
     - ../vars/install_base.yml
   vars:
-    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_nodename }}"
+    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_host }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   pre_tasks:

--- a/pipelines/upgrade/11-smoker.yml
+++ b/pipelines/upgrade/11-smoker.yml
@@ -5,7 +5,7 @@
   vars_files:
     - ../vars/upgrade_base.yml
   vars:
-    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_nodename }}"
+    smoker_base_url: "https://{{ hostvars[forklift_server_name].ansible_host }}"
     smoker_variables:
       password: "{{ foreman_installer_admin_password|default('changeme') }}"
   pre_tasks:


### PR DESCRIPTION
ansible_nodename is the "real" hostname (as in `hostname -f`), which we update in some tests via `katello-change-hostname` but do not properly propagate to poor-CIs-DNS (aka /etc/hosts).
instead of trying to fix DNS, we can just configure smoker to use ansible_host, which is the value from the inventory and that is always reachable (as it is the IP in the case of the Vagrant inventory).