### PR TITLE
Bump Pulpcore repository to 3.22

### DIFF
--- a/roles/pulpcore_repositories/defaults/main.yml
+++ b/roles/pulpcore_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-pulpcore_repositories_version: '3.21'
+pulpcore_repositories_version: '3.22'


### PR DESCRIPTION
Bumps the Pulpcore repository version to 3.22 to match the recent Katello updates.