### PR TITLE
Add task to fix .env files in foreman

### DIFF
--- a/roles/customize_home/tasks/fix_env.yml
+++ b/roles/customize_home/tasks/fix_env.yml
@@ -1,0 +1,11 @@
+- name: Check that the .env exists
+  stat:
+    path: /home/vagrant/foreman/.env
+  register: stat_result
+
+- name: Ensure .env file contains current hostname
+  ansible.builtin.replace:
+    path: /home/vagrant/foreman/.env
+    regexp: '(.*)--public [a-zA-Z0-9-\.]*(.*)'
+    replace: '\1--public {{ ansible_fqdn }}\2'
+  when: stat_result

--- a/roles/customize_home/tasks/main.yml
+++ b/roles/customize_home/tasks/main.yml
@@ -19,6 +19,8 @@
 - include_tasks: clone_specified_repo.yml
   when: customize_home_git_repo is defined
 
+- include_tasks: fix_env.yml
+
 - name: Check custom bootstrap script exists
   stat:
     path: "{{ ansible_env.HOME }}/{{ customize_home_bootstrap_script }}"


### PR DESCRIPTION
When using a stable box, changing the hostname results in a broken installation. Foreman properly detects the hostname, but webpack is started with the hostname of the installation which is written to ~/foreman/.env Ensure the --public argument reflects the current hostname