### PR TITLE
Update CentOS Stream base boxes

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -40,4 +40,4 @@ boxes:
   centos9-stream:
     box_name: 'centos/stream9'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20221206.0.x86_64.vagrant-libvirt.box
+    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230410.0.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
Since these are not maintained on Vagrant Cloud, we need to keep track of them manually. This updates to the latest built images.

I did open https://gitlab.com/redhat/centos-stream/release-engineering/releng-tools/-/merge_requests/116 in order to start the process, but so far there's little response.