### PR TITLE
update centos8 stream box

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -31,7 +31,7 @@ boxes:
   centos8-stream:
     box_name: 'centos/stream8'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20220913.0.x86_64.vagrant-libvirt.box
+    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230501.0.x86_64.vagrant-libvirt.box
     pty: true
     scenarios:
       - foreman


### PR DESCRIPTION
this boots quickly again:

```
May 02 09:14:36 localhost.localdomain systemd[1]: Startup finished in 1.503s (kernel) + 887ms (initrd) + 4.738s (userspace) = 7.128s.
```