### PR TITLE
give katello and luna pipes more memory

### DIFF
--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -1,6 +1,6 @@
 server_box:
   box: "{{ pipeline_os }}"
-  memory: 8192
+  memory: 10240
   ansible:
     variables:
       foreman_server_repositories_katello: true

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -1,6 +1,6 @@
 server_box:
   box: "{{ pipeline_os }}"
-  memory: 8192
+  memory: 10240
   ansible:
     variables:
       foreman_server_repositories_katello: true


### PR DESCRIPTION
the hypervisors we're running CI on have 192GB RAM, so we could go even further, but our pipelines should also be able to run on developer machines, so let's not increase it too much.