### PR TITLE
Align Pulp repository defaults to 2.22

### DIFF
--- a/roles/katello_repositories/defaults/main.yml
+++ b/roles/katello_repositories/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 katello_repositories_version: nightly
 katello_repositories_environment: "{{ foreman_repositories_environment | default('release') }}"
-katello_repositories_pulp_version: 2.21
+katello_repositories_pulp_version: '2.22'
 katello_repositories_pulp_release: stable

--- a/roles/pulp_repositories/defaults/main.yml
+++ b/roles/pulp_repositories/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-pulp_repositories_version: '2.21'
+pulp_repositories_version: '2.22'
 pulp_repositories_release: 'stable'


### PR DESCRIPTION
This matches what Katello currently uses.