### PR TITLE
Fix telemetry dependencies

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -45,7 +45,7 @@
           - opentelemetry-api
           - opentelemetry-sdk
           - opentelemetry-exporter-otlp
-        executable: pip3.9
+        executable: pip3.11
       when:
         - forklift_telemetry|default(false)
         - ansible_distribution_major_version != '7'


### PR DESCRIPTION
Looks like pip3.9 no longer exists by default on Centos8 Stream, since we install ansible, 3.11 should be installed by default now, if 3.9 is really necessary we can install python39 in the `Install Forklift Dependencies` step.

Foreman Nightly and Katello 4.9 are failing with this atm.