### PR TITLE
Add pip3.11 for telemetry

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -37,6 +37,16 @@
           - rubygem-deep_merge
         state: 'present'
 
+    - name: 'Install pip3.11 for telemetry'
+      become: true
+      package:
+        name:
+          - python3.11-pip
+        state: 'present'
+      when:
+        - forklift_telemetry|default(false)
+        - ansible_distribution_major_version != '7'
+
     - name: 'install telemetry dependencies'
       become: true
       pip:


### PR DESCRIPTION
Looks like #1681 didn't solved the issue, nightly is failing even after merging that, this will make sure that pip3.11 is present.