### PR TITLE
Fix foreman_helper tSkipIfNewerThan45 to not match 4.10+

### DIFF
--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -37,7 +37,7 @@ tSkipIfOlderThan43() {
 
 tSkipIfNewerThan45() {
   KATELLO_VERSION=$(tKatelloVersion)
-  if [[ $KATELLO_VERSION != 4.[0-5]* ]]; then
+  if [[ $KATELLO_VERSION != 4.[0-5]* || $KATELLO_VERSION == 4.[0-9][0-9]* ]]; then
     skip "Skip if Katello is newer than 4.5"
   fi
 }


### PR DESCRIPTION
Should fix the broken nightly Katello pipeline.