### PR TITLE
Use latest CentOS Vagrant images

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -31,7 +31,7 @@ boxes:
   centos8-stream:
     box_name: 'centos/stream8'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230501.0.x86_64.vagrant-libvirt.box
+    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box
     pty: true
     scenarios:
       - foreman
@@ -40,4 +40,4 @@ boxes:
   centos9-stream:
     box_name: 'centos/stream9'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230516.0.x86_64.vagrant-libvirt.box
+    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
While the boxes aren't uploaded to Vagrant Cloud yet, they are now uploaded with a stable -latest URL so that can be used.