### PR TITLE
Use CentOS Stream 9 from Vagrant Cloud

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -40,4 +40,3 @@ boxes:
   centos9-stream:
     box_name: 'centos/stream9'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
CentOS has started to publish the boxes. Using it from the official location allows vagrant box update to work. It's also fewer things to maintain.