### PR TITLE
Allow /dev/sda in addition to /dev/vda

### DIFF
--- a/playbooks/resize_disk.yml
+++ b/playbooks/resize_disk.yml
@@ -22,7 +22,7 @@
       when: '"ext4" in root_partition.stdout'
 
     - name: Extend partition
-      command: growpart /dev/vda {{ root_partition.stdout.split(' ')[0].replace('/dev/vda', '') }}
+      command: growpart {{ root_partition.stdout | regex_replace('^(/dev/[sv]da)(\d+) .+$', '\1 \2') }}
       register: growpart_output
       failed_when:
         - growpart_output.rc != 0


### PR DESCRIPTION
My Vagrant machine comes up with `/dev/sda`, not `/dev/vda`, I assume because I'm [using the VirtualBox provider](https://github.com/theforeman/forklift/pull/1217#discussion_r518057186), and as a result a `vagrant up centos8-stream-foreman-nightly` produces

```
TASK [Extend partition] ********************************************************
fatal: [centos8-stream-foreman-nightly]: FAILED! => changed=true 
  cmd:
  - growpart
  - /dev/vda
  - /dev/sda1
  delta: '0:00:00.008682'
  end: '2023-08-11 17:59:59.701082'
  failed_when_result: true
  msg: non-zero return code
  rc: 2
  start: '2023-08-11 17:59:59.692400'
  stderr: ''
  stderr_lines: <omitted>
  stdout: 'FAILED: /dev/vda: does not exist'
  stdout_lines: <omitted>
```

