### PR TITLE
Use the latest Vagrant centos8-stream image

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -31,7 +31,6 @@ boxes:
   centos8-stream:
     box_name: 'centos/stream8'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box
     pty: true
     scenarios:
       - foreman


### PR DESCRIPTION
Recently CentOS has started to publish Stream 8 boxes to Vagrant Cloud again, so it's no longer needed to specify the URL directly. This has the benefit that vagrant box update can work.