### PR TITLE
Revert "Use the latest Vagrant centos8-stream image"

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -31,6 +31,7 @@ boxes:
   centos8-stream:
     box_name: 'centos/stream8'
     disk_size: 40
+    libvirt: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box
     pty: true
     scenarios:
       - foreman


### PR DESCRIPTION
Reverts theforeman/forklift#1696

Reverting, because the new images 404:

```
[2023-08-27T21:56:44.070Z] TASK [forklift : Bring up boxes] ***********************************************

[2023-08-27T21:56:44.070Z] fatal: [localhost]: FAILED! => changed=true 

[2023-08-27T21:56:44.070Z]   cmd:

[2023-08-27T21:56:44.070Z]   - vagrant

[2023-08-27T21:56:44.070Z]   - up

[2023-08-27T21:56:44.070Z]   - --no-parallel

[2023-08-27T21:56:44.070Z]   - pipe-foreman-server-nightly-centos8-stream

[2023-08-27T21:56:44.070Z]   - pipe-foreman-smoker-nightly-centos8-stream

[2023-08-27T21:56:44.070Z]   delta: '0:00:03.067893'

[2023-08-27T21:56:44.070Z]   end: '2023-08-27 21:56:43.902057'

[2023-08-27T21:56:44.070Z]   msg: non-zero return code

[2023-08-27T21:56:44.070Z]   rc: 1

[2023-08-27T21:56:44.070Z]   start: '2023-08-27 21:56:40.834164'

[2023-08-27T21:56:44.070Z]   stderr: |-

[2023-08-27T21:56:44.070Z]     An error occurred while downloading the remote file. The error

[2023-08-27T21:56:44.070Z]     message, if any, is reproduced below. Please fix this error and try

[2023-08-27T21:56:44.070Z]     again.

[2023-08-27T21:56:44.070Z]   

[2023-08-27T21:56:44.070Z]     The requested URL returned error: 404 Not Found

[2023-08-27T21:56:44.071Z]   stderr_lines: <omitted>

[2023-08-27T21:56:44.071Z]   stdout: |-

[2023-08-27T21:56:44.071Z]     Bringing machine 'pipe-foreman-server-nightly-centos8-stream' up with 'libvirt' provider...

[2023-08-27T21:56:44.071Z]     Bringing machine 'pipe-foreman-smoker-nightly-centos8-stream' up with 'libvirt' provider...

[2023-08-27T21:56:44.071Z]     ==> pipe-foreman-server-nightly-centos8-stream: Libvirt Provider: volume_cache is deprecated. Use disk_driver :cache => 'unsafe' instead.

[2023-08-27T21:56:44.071Z]     ==> pipe-foreman-server-nightly-centos8-stream: Box 'centos/stream8' could not be found. Attempting to find and install...

[2023-08-27T21:56:44.071Z]         pipe-foreman-server-nightly-centos8-stream: Box Provider: libvirt

[2023-08-27T21:56:44.071Z]         pipe-foreman-server-nightly-centos8-stream: Box Version: >= 0

[2023-08-27T21:56:44.071Z]     ==> pipe-foreman-server-nightly-centos8-stream: Loading metadata for box 'centos/stream8'

[2023-08-27T21:56:44.071Z]         pipe-foreman-server-nightly-centos8-stream: URL: https://vagrantcloud.com/centos/stream8

[2023-08-27T21:56:44.071Z]     ==> pipe-foreman-server-nightly-centos8-stream: Adding box 'centos/stream8' (v20230710.0) for provider: libvirt

[2023-08-27T21:56:44.071Z]         pipe-foreman-server-nightly-centos8-stream: Downloading: https://vagrantcloud.com/centos/boxes/stream8/versions/20230710.0/providers/libvirt.box

[2023-08-27T21:56:44.071Z]     [KProgress: 0% (Rate: 0*/s, Estimated time remaining: --:--:--)[KProgress: 100% (Rate: 832/s, Estimated time remaining: --:--:--)[KDownload redirected to host: cloud.centos.org

[2023-08-27T21:56:44.071Z]     [K

[2023-08-27T21:56:44.071Z]   stdout_lines: <omitted>
```

:eyes: @ekohl 