### PR TITLE
Remove rex from katello_devel role to prevent install error

### DIFF
--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -22,5 +22,4 @@ dependencies:
       - "{{ '--katello-devel-scl-ruby=' +  ruby_scl_version if ansible_distribution_major_version == '7' else '' }}"
       - "--katello-devel-admin-password {{ foreman_installer_admin_password }}"
       - "{{ '--katello-devel-github-username=' + katello_devel_github_username if katello_devel_github_username is defined else '' }}"
-      - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"
   - role: customize_home


### PR DESCRIPTION
With this [commit](https://github.com/theforeman/puppet-katello_devel/commit/e276ccbfc9703501a57ab0df484a9a1af54d0de7) in `katello_devel` we now by default install REX, having it in the role causes this error because we are declaring it twice

<code>
 2023-09-14 13:50:11 [ERROR ] [configure] Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Katello_devel::Plugin[theforeman/foreman_remote_execution] is already declared at (file: /usr/share/foreman-installer/modules/katello_devel/manifests/config.pp, line: 42); cannot redeclare (file: /usr/share/foreman-installer/modules/katello_devel/manifests/config.pp, line: 54) (file: /usr/share/foreman-installer/modules/katello_devel/manifests/config.pp, line: 54, column: 7) on node dhcp-8-29-96.lab.eng.rdu2.redhat.com
    2023-09-14 13:50:11 [NOTICE] [configure] System configuration has finished.
</code>