### PR TITLE
Add Candlepin pipeline to run puppet-candlepin tests

### DIFF
--- a/pipelines/candlepin.yml
+++ b/pipelines/candlepin.yml
@@ -1,0 +1,3 @@
+- import_playbook: candlepin/01-boxes.yml
+- import_playbook: candlepin/02-install.yml
+- import_playbook: candlepin/03-tests.yml

--- a/pipelines/candlepin/01-boxes.yml
+++ b/pipelines/candlepin/01-boxes.yml
@@ -1,0 +1,8 @@
+---
+- name: create vagrant boxes
+  hosts: localhost
+  become: False
+  vars_files:
+    - ../vars/forklift_candlepin.yml
+  roles:
+    - forklift

--- a/pipelines/candlepin/02-install.yml
+++ b/pipelines/candlepin/02-install.yml
@@ -1,0 +1,11 @@
+---
+- name: Setup git repo
+  become: True
+  hosts:
+   - "{{ forklift_name }}"
+  vars_files:
+    - ../vars/forklift_candlepin.yml
+  vars:
+    beaker_puppet_module: "puppet-candlepin"
+  roles:
+    - beaker

--- a/pipelines/candlepin/03-tests.yml
+++ b/pipelines/candlepin/03-tests.yml
@@ -1,0 +1,17 @@
+---
+- name: run tests
+  become: True
+  hosts:
+   - "{{ forklift_name }}"
+  vars_files:
+    - ../vars/forklift_candlepin.yml
+  tasks:
+    - name: Run acceptance tests
+      ansible.builtin.include_role:
+        name: beaker
+        tasks_from: test
+      vars:
+        beaker_puppet_module: "puppet-candlepin"
+        beaker_os: "{{ pipeline_os.replace('-stream', '') }}"
+        beaker_environment:
+          BEAKER_FACTER_CANDLEPIN_BASEURL: "https://stagingyum.theforeman.org/candlepin/{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/x86_64"

--- a/pipelines/vars/forklift_candlepin.yml
+++ b/pipelines/vars/forklift_candlepin.yml
@@ -1,0 +1,8 @@
+forklift_name: "pipe-candlepin-{{ pipeline_version }}-{{ pipeline_os }}"
+
+server_box:
+  box: "{{ pipeline_os }}"
+  memory: 4680
+
+forklift_boxes:
+  "{{ {forklift_name: server_box} }}"

--- a/roles/beaker/defaults/main.yml
+++ b/roles/beaker/defaults/main.yml
@@ -1,0 +1,7 @@
+beaker_base_environment:
+  BEAKER_HYPERVISOR: "docker"
+  BEAKER_provision: "yes"
+  BEAKER_setfile: "{{ beaker_os }}-64{hostname={{ beaker_os }}-64.example.com}"
+  BEAKER_destroy: "no"
+beaker_environment: {}
+beaker_puppet_module_path: "/src/{{ beaker_puppet_module }}"

--- a/roles/beaker/tasks/main.yml
+++ b/roles/beaker/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Install podman-docker
+  package:
+    name: podman-docker
+    state: installed
+
+- name: Start podman
+  service:
+    name: podman
+    state: started
+
+- name: Install git
+  package:
+    name: git
+    state: installed
+
+- name: Enable ruby 2.7 module
+  command: dnf module enable -y ruby:2.7
+  when: ansible_distribution_major_version == "8"
+
+- name: enable powertools
+  command: dnf config-manager --set-enabled powertools
+  when: ansible_distribution_major_version == "8"
+
+- name: enable CRB
+  command: dnf config-manager --set-enabled crb
+  when: ansible_distribution_major_version == "9"
+
+- name: Install Ruby
+  package:
+    state: installed
+    name:
+      - ruby
+      - ruby-devel
+      - rubygem-bundler
+      - gcc-c++
+      - make
+      - redhat-rpm-config
+      - libyaml-devel
+
+- name: Clone puppet module
+  ansible.builtin.git:
+    repo: "https://github.com/theforeman/{{ beaker_puppet_module }}.git"
+    dest: "{{ beaker_puppet_module_path }}"
+    version: "{{ beaker_puppet_module_version | default(omit) }}"
+
+- name: Bundle install
+  command: bundle install
+  args:
+    chdir: "{{ beaker_puppet_module_path }}"

--- a/roles/beaker/tasks/test.yml
+++ b/roles/beaker/tasks/test.yml
@@ -1,0 +1,5 @@
+- name: Run acceptance tests
+  command: bundle exec rake beaker
+  args:
+    chdir: "{{ beaker_puppet_module_path }}"
+  environment: "{{ beaker_base_environment | ansible.builtin.combine(beaker_environment) }}"


### PR DESCRIPTION
Starter test pipeline, this will require some changes to puppet-candlepin to allow configuring the repository to test. My goal is to provide this for https://github.com/theforeman/foreman-infra/issues/1937#issuecomment-1749500409 