### PR TITLE
don't set `priority: 1` when setting up staging repos

### DIFF
--- a/roles/foreman_client_repositories/tasks/_koji_staging_repo.yml
+++ b/roles/foreman_client_repositories/tasks/_koji_staging_repo.yml
@@ -4,7 +4,6 @@
     name: foreman-client-koji
     description: "Foreman {{ foreman_client_repositories_version }} Client Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-client-{{ foreman_client_repositories_version }}/{{ foreman_client_repositories_dists[ansible_os_family] }}{{ ansible_distribution_major_version }}/x86_64/"
-    priority: '1'
     gpgcheck: no
   tags:
     - packages

--- a/roles/foreman_client_repositories/tasks/_stagingyum_staging_repo.yml
+++ b/roles/foreman_client_repositories/tasks/_stagingyum_staging_repo.yml
@@ -4,7 +4,6 @@
     name: foreman-client-staging
     description: "Foreman {{ foreman_client_repositories_version }} Client Staging Repository"
     baseurl: "https://stagingyum.theforeman.org/client/{{ foreman_client_repositories_version }}/{{ foreman_client_repositories_dists[ansible_os_family] }}{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages

--- a/roles/foreman_repositories/tasks/_koji_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/_koji_staging_repos.yml
@@ -4,7 +4,6 @@
     name: foreman-koji
     description: "Foreman {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages
@@ -15,7 +14,6 @@
     state: "{{ foreman_repositories_plugins | ternary('present', 'absent') }}"
     description: "Foreman Plugins {{ foreman_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/foreman-plugins-{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages

--- a/roles/foreman_repositories/tasks/_stagingyum_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/_stagingyum_staging_repos.yml
@@ -4,7 +4,6 @@
     name: foreman-staging
     description: "Foreman {{ foreman_repositories_version }} Staging Repository"
     baseurl: "https://stagingyum.theforeman.org/foreman/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages
@@ -14,7 +13,6 @@
     name: foreman-plugins-staging
     description: "Foreman {{ foreman_repositories_version }} Plugins Staging Repository"
     baseurl: "https://stagingyum.theforeman.org/plugins/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages

--- a/roles/katello_repositories/tasks/_koji_staging_repos.yml
+++ b/roles/katello_repositories/tasks/_koji_staging_repos.yml
@@ -4,7 +4,6 @@
     name: katello-koji
     description: "Katello {{ katello_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: '1'
     gpgcheck: no
 
 - name: 'Candlepin Koji repository'
@@ -12,5 +11,4 @@
     name: candlepin-koji
     description: "Candlepin {{ katello_repositories_version }} Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_repositories_version }}/candlepin/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: '1'
     gpgcheck: no

--- a/roles/katello_repositories/tasks/_stagingyum_staging_repos.yml
+++ b/roles/katello_repositories/tasks/_stagingyum_staging_repos.yml
@@ -4,7 +4,6 @@
     name: katello-staging
     description: "Katello {{ katello_repositories_version }} Staging Repository"
     baseurl: "https://stagingyum.theforeman.org/katello/{{ katello_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages
@@ -14,7 +13,6 @@
     name: candlepin-staging
     description: "Candlepin {{ katello_repositories_version }} Staging Repository"
     baseurl: "https://stagingyum.theforeman.org/candlepin/{{ katello_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
-    priority: "1"
     gpgcheck: no
   tags:
     - packages


### PR DESCRIPTION
Setting `priority=1` means that DNF will always pick packages from this repo over the ones available from other repos, even if those have a higher version [1]:

     If there is more than one candidate package for a particular operation,
     the one from a repo with the lowest priority value is picked, possibly
     despite being less convenient otherwise (e.g. by being a lower version).

This breaks the usage of packit builds, as those don't have a priority set by default (thus getting the default `99` from DNF).

This also means that we potentially test a package that after promotion from staging to prod will never be picked up by the end-user's system as we do not (and should not) set a priority in `foreman-release` (and others).

[1] https://dnf.readthedocs.io/en/latest/conf_ref.html