### PR TITLE
Use a modified pulp_installer for python 3.11+

### DIFF
--- a/requirements-pulp-322.yml
+++ b/requirements-pulp-322.yml
@@ -1,3 +1,3 @@
 collections:
   - name: pulp.pulp_installer
-    version: 3.22.0
+    src: https://github.com/pcreech/pulp-installer


### PR DESCRIPTION
https://github.com/pcreech/pulp_installer has a modification that won't attempt module installs if the pulp_pkg_name_prefix is 'python3.11-'