### PR TITLE
Switch Pulpcore testing to using puppet-pulpcore test suite

### DIFF
--- a/pipelines/pulpcore/01-boxes.yml
+++ b/pipelines/pulpcore/01-boxes.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   become: False
   vars_files:
-    - ../vars/install_base.yml
-    - ../vars/forklift_{{ pipeline_type }}.yml
+    - ../vars/forklift_pulpcore.yml
   roles:
     - forklift

--- a/pipelines/pulpcore/02-install.yml
+++ b/pipelines/pulpcore/02-install.yml
@@ -22,7 +22,7 @@
   become: True
   vars_files:
     - ../vars/install_base.yml
-    - ../vars/forklift_{{ pipeline_type }}.yml
+    - ../vars/forklift_pulpcore.yml
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   pre_tasks:

--- a/pipelines/pulpcore/02-install.yml
+++ b/pipelines/pulpcore/02-install.yml
@@ -1,15 +1,20 @@
 ---
-- name: Setup git repo
+- name: Enable Postgresql 12 module if necessary
   become: True
   hosts:
    - "{{ forklift_name }}"
   vars_files:
     - ../vars/forklift_pulpcore.yml
   tasks:
-    - name: Install podman-docker
-      package:
-        name: podman-docker
-        state: installed
+  - name: Enable postgresql 12 module
+    ansible.builtin.dnf:
+      name: '@postgresql:12'
+      state: present
+    when:
+     - pipeline_version is defined
+     - pipeline_version != 'nightly' or pipeline_version is version('3.40', '<')
+     - pipeline_os is defined
+     - pipeline_os is search("centos8-stream")
 
 - name: install pulpcore
   hosts:
@@ -21,13 +26,33 @@
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   pre_tasks:
-    - when: pipeline_version != 'nightly' and pipeline_version is version('3.28', '<=' )
+    - when: pipeline_version != 'nightly' and pipeline_version is version('3.28', '==' )
       set_fact:
         pulp_pkg_repo: "http://koji.katello.org/releases/yum/pulpcore-{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/$basearch/"
-    - when: pipeline_version == 'nightly' or pipeline_version is version('3.39', '>=')
+    - when: pipeline_version != 'nightly' and pipeline_version is version('3.39', '==')
       set_fact:
         pulp_pkg_repo: "https://stagingyum.theforeman.org/pulpcore/{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/$basearch/"
         pulp_pkg_name_prefix: "python3.11-"
   roles:
-    - epel_repositories
-    - pulp.pulp_installer.pulp_all_services
+    - role: epel_repositories
+      when:
+        - pipeline_version is defined
+        - pipeline_version != 'nightly' and pipeline_version is version('3.28', '==' )
+    - role: pulp.pulp_installer.pulp_all_services
+      when:
+        - pipeline_version is defined
+        - pipeline_version != 'nightly' or pipeline_version is version('3.39', '==')
+
+- name: Setup git repo
+  become: True
+  hosts:
+   - "{{ forklift_name }}"
+  vars_files:
+    - ../vars/forklift_pulpcore.yml
+  vars:
+    beaker_puppet_module: "puppet-pulpcore"
+  roles:
+    - role: beaker
+      when:
+        - pipeline_version is defined
+        - pipeline_version == 'nightly' or pipeline_version is version('3.40', '>=')

--- a/pipelines/pulpcore/02-install.yml
+++ b/pipelines/pulpcore/02-install.yml
@@ -1,22 +1,15 @@
 ---
-- name: Enable Postgresql 12 module if necessary
+- name: Setup git repo
   become: True
   hosts:
-   - "{{ forklift_server_name }}"
+   - "{{ forklift_name }}"
   vars_files:
-    - ../vars/install_base.yml
-    - ../vars/forklift_{{ pipeline_type }}.yml
-
+    - ../vars/forklift_pulpcore.yml
   tasks:
-  - name: Enable postgresql 12 module
-    ansible.builtin.dnf:
-      name: '@postgresql:12'
-      state: present
-    when:
-     - pipeline_version is defined
-     - pipeline_version == 'nightly' or pipeline_version is version('3.28', '>=')
-     - pipeline_os is defined
-     - pipeline_os is search("centos8-stream")
+    - name: Install podman-docker
+      package:
+        name: podman-docker
+        state: installed
 
 - name: install pulpcore
   hosts:

--- a/pipelines/pulpcore/03-tests.yml
+++ b/pipelines/pulpcore/03-tests.yml
@@ -1,5 +1,5 @@
 ---
-- name: run tests
+- name: run tests beaker
   become: True
   hosts:
    - "{{ forklift_name }}"
@@ -7,12 +7,26 @@
     - ../vars/forklift_pulpcore.yml
   tasks:
     - name: Run acceptance tests
-      command: bundle exec rake beaker
-      args:
-        chdir: /src/puppet-pulpcore
-      environment:
-        BEAKER_HYPERVISOR: "docker"
-        BEAKER_provision: "yes"
-        BEAKER_setfile: "centos8-64{hostname=centos8-64.example.com}"
-        BEAKER_destroy: "no"
-        BEAKER_FACTER_PULPCORE_VERSION: "{{ pipeline_version }}"
+      ansible.builtin.include_role:
+        name: beaker
+        tasks_from: test
+      when:
+        - pipeline_version == 'nightly' or pipeline_version is version('3.40, '>=' )
+      vars:
+        beaker_puppet_module: "puppet-pulpcore"
+        beaker_os: "{{ pipeline_os.replace('-stream', '') }}"
+        beaker_environment:
+          BEAKER_FACTER_PULPCORE_BASEURL: "https://stagingyum.theforeman.org/pulpcore/{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/x86_64"
+
+- name: run tests ansible
+  become: True
+  hosts:
+   - "{{ forklift_name }}"
+  vars_files:
+    - ../vars/install_base.yml
+    - ../vars/forklift_{{ pipeline_type }}.yml
+  roles:
+    - role: pulp.pulp_installer.pulp_health_check
+      when:
+        - pipeline_version is defined
+        - pipeline_version != 'nightly' or pipeline_version is version('3.39', '<=' )

--- a/pipelines/pulpcore/03-tests.yml
+++ b/pipelines/pulpcore/03-tests.yml
@@ -24,7 +24,7 @@
    - "{{ forklift_name }}"
   vars_files:
     - ../vars/install_base.yml
-    - ../vars/forklift_{{ pipeline_type }}.yml
+    - ../vars/forklift_pulpcore.yml
   roles:
     - role: pulp.pulp_installer.pulp_health_check
       when:

--- a/pipelines/pulpcore/03-tests.yml
+++ b/pipelines/pulpcore/03-tests.yml
@@ -1,10 +1,18 @@
 ---
 - name: run tests
-  hosts:
-    - "{{ forklift_server_name }}"
   become: True
+  hosts:
+   - "{{ forklift_name }}"
   vars_files:
-    - ../vars/install_base.yml
-    - ../vars/forklift_{{ pipeline_type }}.yml
-  roles:
-    - pulp.pulp_installer.pulp_health_check
+    - ../vars/forklift_pulpcore.yml
+  tasks:
+    - name: Run acceptance tests
+      command: bundle exec rake beaker
+      args:
+        chdir: /src/puppet-pulpcore
+      environment:
+        BEAKER_HYPERVISOR: "docker"
+        BEAKER_provision: "yes"
+        BEAKER_setfile: "centos8-64{hostname=centos8-64.example.com}"
+        BEAKER_destroy: "no"
+        BEAKER_FACTER_PULPCORE_VERSION: "{{ pipeline_version }}"

--- a/pipelines/vars/forklift_pulpcore.yml
+++ b/pipelines/vars/forklift_pulpcore.yml
@@ -1,4 +1,4 @@
-forklift_name: "pipe-pulp-{{ pipeline_version }}-{{ pipeline_os }}"
+forklift_name: "pipe-pulpcore-{{ pipeline_version }}-{{ pipeline_os }}"
 
 server_box:
   box: "{{ pipeline_server_os | default(pipeline_os) }}"

--- a/pipelines/vars/forklift_pulpcore.yml
+++ b/pipelines/vars/forklift_pulpcore.yml
@@ -1,9 +1,11 @@
+forklift_name: "pipe-pulp-{{ pipeline_version }}-{{ pipeline_os }}"
+
 server_box:
   box: "{{ pipeline_server_os | default(pipeline_os) }}"
   memory: 4680
 
 forklift_boxes:
-  "{{ {forklift_server_name: server_box} }}"
+  "{{ {forklift_name: server_box} }}"
 
 pulp_install_source: packages
 pulp_pkg_repo_gpgcheck: False

--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -80,7 +80,7 @@
       retries: 3
       when: forklift_install_from_galaxy
 
-    - name: 'Install Forklift Pulp collection dependencies for <3.17'
+    - name: 'Install Forklift Pulp collection dependencies for 3.28'
       command:
         cmd: ansible-galaxy collection install -r requirements-pulp.yml
         chdir: "{{ forklift_dest }}"
@@ -88,33 +88,19 @@
         - forklift_install_pulp_from_galaxy
         - pipeline_version is defined
         - pipeline_version != 'nightly'
-        - pipeline_version is version('3.17', '<=')
+        - pipeline_version is version('3.28', '==')
       retries: 3
       register: result
       until: result is succeeded
 
-    - name: 'Install Forklift Pulp collection dependencies for >3.18'
-      command:
-        cmd: ansible-galaxy collection install -r requirements-pulp-322.yml
-        chdir: "{{ forklift_dest }}"
-      when:
-        - forklift_install_pulp_from_galaxy
-        - pipeline_version is defined
-        - pipeline_version != 'nightly'
-        - pipeline_version is version('3.18', '>=')
-        - pipeline_version is version('3.39', '<')
-      retries: 3
-      register: result
-      until: result is succeeded
-
-    - name: 'Install Forklift Pulp collection dependencies for >3.39'
+    - name: 'Install Forklift Pulp collection dependencies for 3.39'
       command:
         cmd: ansible-galaxy collection install -r requirements-pulp-339.yml
         chdir: "{{ forklift_dest }}"
       when:
         - forklift_install_pulp_from_galaxy
         - pipeline_version is defined
-        - pipeline_version == 'nightly' or pipeline_version is version('3.39', '>=')
+        - pipeline_version is version('3.39', '==')
       retries: 3
       register: result
       until: result is succeeded

--- a/requirements-pulp-322.yml
+++ b/requirements-pulp-322.yml
@@ -1,3 +1,0 @@
-collections:
-  - name: pulp.pulp_installer
-    version: 3.22.0

--- a/requirements-pulp.yml
+++ b/requirements-pulp.yml
@@ -1,3 +1,3 @@
 collections:
   - name: pulp.pulp_installer
-    version: 3.15.9-4
+    version: 3.22.0


### PR DESCRIPTION
Given we install Pulpcore using puppet-pulpcore, the idea here is to vet packaging changes against the puppet module rather than the Pulp Ansible installer.

This is in draft mode because first the puppet module needs to support configuring the baseurl in order to point the testing at `stagingyum.theforeman.org`.