### PR TITLE
Still create IMPORT_ORG, to help minimize fix removal vector

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -192,8 +192,6 @@ setup() {
 }
 
 @test "create org for library import" {
-  tSkipIfPulp339
-
   hammer organization create --name="${LIBRARY_IMPORT_ORG}"
 }
 


### PR DESCRIPTION
fb-destroy-organization still expects IMPORT_ORG to exist.  To keep the changes minimalized to this file, let's create the IMPORT_ORG still.