### PR TITLE
always check smoker results, not only for nightly

### DIFF
--- a/pipelines/install/06-smoker.yml
+++ b/pipelines/install/06-smoker.yml
@@ -20,5 +20,3 @@
       become: true
     - podman
     - role: smoker
-      vars:
-        pytest_project_ignore_errors: "{{ (pipeline_version != 'nightly') }}"

--- a/pipelines/upgrade/11-smoker.yml
+++ b/pipelines/upgrade/11-smoker.yml
@@ -20,5 +20,3 @@
       become: true
     - podman
     - role: smoker
-      vars:
-        pytest_project_ignore_errors: "{{ (pipeline_version != 'nightly') }}"


### PR DESCRIPTION
we've been running nightly with smoker on for a year now (the old "nightly" only code was added in c112bb8e50364ce8c5db3278a4d7e1f47eca17ea) which makes me assume all releases since then should be clean