### PR TITLE
clean up old Ubuntu initrds

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -7,3 +7,9 @@
     vtype: boolean
   when:
     - ansible_os_family == 'Debian'
+
+# workaround for https://github.com/lavabit/robox/issues/294
+- name: clean up old Ubuntu initrds
+  shell: rm -f /boot/*-generic.img
+  when:
+    - ansible_os_family == 'Debian'


### PR DESCRIPTION
for some reason /boot contains both initrds with and without .img even if the ones with are not used, however, as /boot space is limited they prevent upgrades of packages, failing our pipelines

delete them

we don't really care about new kernels, or rebooting those VMs, but we care about updated userland, and this prevents it