### PR TITLE
Fix stagingyum repositories URLs

### DIFF
--- a/roles/foreman_repositories/tasks/_stagingyum_staging_repos.yml
+++ b/roles/foreman_repositories/tasks/_stagingyum_staging_repos.yml
@@ -1,18 +1,18 @@
 ---
-- name: 'Foreman {{ foreman_repositories_version }} Staging repository'
+- name: 'Foreman Nightly Staging repository'
   yum_repository:
     name: foreman-staging
-    description: "Foreman {{ foreman_repositories_version }} Staging Repository"
-    baseurl: "https://stagingyum.theforeman.org/foreman/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
+    description: "Foreman Nightly Staging Repository"
+    baseurl: "https://stagingyum.theforeman.org/foreman/nightly/el{{ ansible_distribution_major_version }}/x86_64/"
     gpgcheck: no
   tags:
     - packages
 
-- name: 'Foreman {{ foreman_repositories_version }} Plugins Staging repository'
+- name: 'Foreman Nightly Plugins Staging repository'
   yum_repository:
     name: foreman-plugins-staging
-    description: "Foreman {{ foreman_repositories_version }} Plugins Staging Repository"
-    baseurl: "https://stagingyum.theforeman.org/plugins/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
+    description: "Foreman Nightly Plugins Staging Repository"
+    baseurl: "https://stagingyum.theforeman.org/plugins/nightly/el{{ ansible_distribution_major_version }}/x86_64/"
     gpgcheck: no
   tags:
     - packages

--- a/roles/katello_repositories/tasks/_stagingyum_staging_repos.yml
+++ b/roles/katello_repositories/tasks/_stagingyum_staging_repos.yml
@@ -1,9 +1,9 @@
 ---
-- name: 'Katello {{ katello_repositories_version }} Staging repository'
+- name: 'Katello Nightly Staging repository'
   yum_repository:
     name: katello-staging
-    description: "Katello {{ katello_repositories_version }} Staging Repository"
-    baseurl: "https://stagingyum.theforeman.org/katello/{{ katello_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/"
+    description: "Katello Nightly Staging Repository"
+    baseurl: "https://stagingyum.theforeman.org/katello/nightly/el{{ ansible_distribution_major_version }}/x86_64/"
     gpgcheck: no
   tags:
     - packages


### PR DESCRIPTION
https://stagingyum.theforeman.org/foreman/staging/el8/x86_64/ returns 404, it should be https://stagingyum.theforeman.org/foreman/nightly/el8/x86_64/

This fixes the issue for those who don't have in their box yaml: katello_repositories_version: nightly