### PR TITLE
don't lower() the packit pr data before manging it

### DIFF
--- a/roles/packit/tasks/main.yml
+++ b/roles/packit/tasks/main.yml
@@ -5,7 +5,7 @@
     chroot: "rhel-{{ ansible_distribution_major_version }}-x86_64"
   loop: "{{ packit_prs | default([]) }}"
   vars:
-    packit_data: "{{ item.lower().replace('https://github.com/', '').replace('/pull', '').split('/') }}"
+    packit_data: "{{ item.replace('https://github.com/', '').replace('/pull', '').split('/') }}"
     packit_org: "{{ packit_data[0] }}"
     packit_repo: "{{ packit_data[1] }}"
     packit_pr: "{{ packit_data[2] }}"


### PR DESCRIPTION
packit coprs are case sensitive (it's Katello, not katello), but the lower() was breaking that.

the original idea was that the lower() catches GitHub.COM and other spellings, but it seems to do more harm than good, so let's remove it