### PR TITLE
Use firefox with Smoker

### DIFF
--- a/roles/smoker/defaults/main.yml
+++ b/roles/smoker/defaults/main.yml
@@ -5,8 +5,7 @@ smoker_directory: "{{ ansible_env.HOME }}/smoker"
 smoker_variables: {}
 smoker_variables_path: "{{ smoker_directory }}/variables.json"
 smoker_base_url:
-smoker_command_args: "--driver chrome --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
+smoker_command_args: "--driver firefox --variables '{{ smoker_variables_path }}' --base-url '{{ smoker_base_url }}' --html 'report/htmlreport.html' -vv --numprocesses 2"
 smoker_markers:
 smoker_browser_packages:
-  - chromium
-  - chromedriver
+  - firefox


### PR DESCRIPTION
In Chrome 121 there's a memory leak when using chromedriver. This is fixed with 122, but that's not available yet.

Untested right now.