### PR TITLE
default to stagingyum for staging repos

### DIFF
--- a/roles/foreman_repositories/defaults/main.yml
+++ b/roles/foreman_repositories/defaults/main.yml
@@ -2,4 +2,4 @@
 foreman_repositories_version: nightly
 foreman_repositories_environment: release
 foreman_repositories_plugins: true
-foreman_repositories_staging_source: koji
+foreman_repositories_staging_source: stagingyum

--- a/roles/katello_repositories/defaults/main.yml
+++ b/roles/katello_repositories/defaults/main.yml
@@ -2,4 +2,4 @@
 katello_repositories_version: nightly
 katello_repositories_environment: "{{ foreman_repositories_environment | default('release') }}"
 katello_repositories_pulp_release: stable
-katello_repositories_staging_source: 'koji'
+katello_repositories_staging_source: 'stagingyum'


### PR DESCRIPTION
koji is not used anymore, and the pipelines have an own version-based definition to get stuff from koji for old releases