### PR TITLE
pass the pipeline version to beaker

### DIFF
--- a/pipelines/pulpcore/03-tests.yml
+++ b/pipelines/pulpcore/03-tests.yml
@@ -18,6 +18,7 @@
         beaker_os: "{{ pipeline_os.replace('-stream', '') }}"
         beaker_environment:
           BEAKER_FACTER_PULPCORE_BASEURL: "https://stagingyum.theforeman.org/pulpcore/{{ pipeline_version }}/el{{ ansible_distribution_major_version }}/x86_64"
+          BEAKER_FACTER_PULPCORE_VERSION: "{{ pipeline_version }}"
 
 - name: run tests ansible
   become: True


### PR DESCRIPTION
our nightly repos are unsigned and if you pass version=nightly to pulpcore::repo it will disable gpg checking, otherwise things don't install