### PR TITLE
Drop katello_repositories_pulp_release references

### DIFF
--- a/pipelines/vars/repos_release.yml
+++ b/pipelines/vars/repos_release.yml
@@ -1,4 +1,3 @@
 katello_repositories_environment: release
-katello_repositories_pulp_release: stable
 foreman_repositories_environment: release
 foreman_client_repositories_environment: release

--- a/pipelines/vars/repos_staging.yml
+++ b/pipelines/vars/repos_staging.yml
@@ -1,5 +1,4 @@
 katello_repositories_environment: staging
-katello_repositories_pulp_release: stable
 foreman_repositories_environment: staging
 foreman_client_repositories_environment: staging
 foreman_repositories_staging_source: "{{ 'stagingyum' if (pipeline_version == 'nightly' or pipeline_version is version('3.9', '>=')) else 'koji' }}"

--- a/roles/katello_repositories/defaults/main.yml
+++ b/roles/katello_repositories/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 katello_repositories_version: nightly
 katello_repositories_environment: "{{ foreman_repositories_environment | default('release') }}"
-katello_repositories_pulp_release: stable
 katello_repositories_staging_source: 'stagingyum'


### PR DESCRIPTION
This was used for Pulp 2 repositories, but we dropped those.

Fixes: 2729a628810c44b980f0ecf947054146c38c8db9 ("drop support for enabling pulp staging repos")