### PR TITLE
Drop installation of puppetlabs-vcsrepo for devel

### DIFF
--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -50,9 +50,6 @@
     name: puppet-agent
     state: present
 
-- name: 'Install puppetlabs-vcsrepo'
-  shell: "/opt/puppetlabs/puppet/bin/puppet module install --ignore-dependencies --target-dir {{ foreman_installer_devel_scenario_modules }} puppetlabs-vcsrepo"
-
 - name: "Install gems to rebuild the kafo module cache"
   gem:
     name: puppet-strings


### PR DESCRIPTION
Since Foreman 3.8 this module is included in the installer.