### PR TITLE
put cirrus-vga on a high PCI slot, so it doesn't clash

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -19,6 +19,10 @@
       sync_type: disabled
       libvirt_options:
         volume_cache: unsafe
+        graphics_type: none
+        qemu_args:
+          - :value: '-device'
+          - :value: 'cirrus-vga,id=video0'
       boxes:
         exclude:
           - '^[^p]'

--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -22,7 +22,7 @@
         graphics_type: none
         qemu_args:
           - :value: '-device'
-          - :value: 'cirrus-vga,id=video0'
+          - :value: 'cirrus-vga,id=video0,bus=pci.0,addr=0x9'
       boxes:
         exclude:
           - '^[^p]'


### PR DESCRIPTION
VGA cards get PCI slot 2 by default from QEMU [1], however, as we
actually disable graphics (so that we don't race for an VNC port), QEMU
thinks it's smart and also gives slot 2 to the storage controller,
leading to:

    Call to virDomainCreateWithFlags failed: internal error:
    QEMU unexpectedly closed the monitor (vm='forklift_debian11'):
    qemu-system-x86_64: -device {"driver":"virtio-blk-pci","bus":"pci.0","addr":"0x2","drive":"libvirt-1-format","id":"ua-box-volume-0","bootindex":1,"write-cache":"on"}:
    PCI: slot 2 function 0 not available for virtio-blk-pci, in use by cirrus-vga,id=video0 (Libvirt::Error)

Let's be smarter than QEMU and plug our unused video card (that is
needed for [2]) into slot 9 instead.

[1] https://libvirt.org/pci-addresses.html
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1021298