### PR TITLE
don't run tests for plugins upgrades twice

### DIFF
--- a/pipelines/upgrade/08-tests.yml
+++ b/pipelines/upgrade/08-tests.yml
@@ -27,3 +27,4 @@
     - role: foreman_testing
       when:
         - pipeline_type != 'foreman'
+        - pipeline_type != 'plugins'


### PR DESCRIPTION
we have two "tests" steps in the upgrade pipe: before and after the
proxy upgrade, but given we only have proxies for katello/luna these
days, we exclude the "pre proxy upgrade" one from the plain "foreman"
pipe. we should also exclude it from the "plugins" pipe, as that too
doesn't have a proxy
