### PR TITLE
remove *_repositories_staging_source variables from katello_devel

### DIFF
--- a/roles/katello_devel/meta/main.yml
+++ b/roles/katello_devel/meta/main.yml
@@ -4,9 +4,7 @@ dependencies:
   - role: foreman_server_repositories
     become: true
     foreman_server_repositories_katello: true
-    foreman_repositories_staging_source: 'stagingyum'
     foreman_server_repositories_foreman_client: true
-    katello_repositories_staging_source: 'stagingyum'
 #   puppet 6 is still the default for theforeman.operations.puppet_repositories as of release 1.2.3
     foreman_puppet_repositories_version: 7
   - role: foreman_installer_devel_scenario

--- a/roles/katello_repositories/tasks/staging_repos.yml
+++ b/roles/katello_repositories/tasks/staging_repos.yml
@@ -30,4 +30,3 @@
 - name: 'Add Candlepin repository'
   include_role:
     name: candlepin_repositories
-  when: candlepin_repositories_version is defined or katello_repositories_staging_source == "stagingyum"


### PR DESCRIPTION
These are no longer needed since https://github.com/theforeman/forklift/pull/1800
See also: https://github.com/theforeman/forklift/pull/1761/files#r1484290004