### PR TITLE
include packit role when cloning

### DIFF
--- a/pipelines/clone/02-setup.yml
+++ b/pipelines/clone/02-setup.yml
@@ -15,4 +15,5 @@
     - role: enable_ipv6
     - role: disable_firewall
     - role: foreman_server_repositories
+    - role: packit
     - role: update_os_packages


### PR DESCRIPTION
we do not use the meta "foreman" role here which usually pulls that in
