### PR TITLE
Pull in puppet/rhsm module when running devel on rhel 9

### DIFF
--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -54,3 +54,11 @@
   gem:
     name: puppet-strings
     executable: /opt/puppetlabs/puppet/bin/gem
+
+- name: 'Install puppet/rhsm puppet module'
+  command: "/opt/puppetlabs/bin/puppet module install puppet-rhsm --target-dir {{ foreman_installer_devel_scenario_modules }}"
+  args:
+    creates: "{{ foreman_installer_devel_scenario_modules }}/rhsm"
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '9'


### PR DESCRIPTION
is required for:
- https://github.com/theforeman/puppet-katello_devel/pull/303