### PR TITLE
Clone test gems to katello.local.rb to allow local katello testing

### DIFF
--- a/roles/customize_home/tasks/main.yml
+++ b/roles/customize_home/tasks/main.yml
@@ -11,6 +11,43 @@
     dest: "{{ ansible_env.HOME }}"
   when: custom_home.stat.isdir is defined and custom_home.stat.isdir
 
+- name: Check if ~/katello/gemfile.d directory exists
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/katello/gemfile.d"
+  register: katello_gemfile_dir
+
+- name: Check if ~/foreman/bundler.d/katello.local.rb file exists
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/foreman/bundler.d/katello.local.rb"
+  register: katello_local_rb_file
+
+- name: Find all .rb filepaths
+  ansible.builtin.find:
+    paths: "{{ ansible_user_dir }}/katello/gemfile.d"
+    patterns: '*.rb'
+  register: found_files
+  when: katello_gemfile_dir.stat.exists and katello_local_rb_file.stat.exists
+
+- name: Read the contents of all .rb files
+  ansible.builtin.slurp:
+    src: "{{ item.path }}"
+  loop: "{{ found_files.files }}"
+  register: found_file_contents
+  when: katello_gemfile_dir.stat.exists and katello_local_rb_file.stat.exists
+
+- name: Ensure encoding is base 64
+  ansible.builtin.fail:
+    msg: "File {{ item.item.path }} is not base64 encoded"
+  loop: "{{ found_file_contents.results }}"
+  when: katello_gemfile_dir.stat.exists and katello_local_rb_file.stat.exists and item.encoding != "base64"
+
+- name: Append .rb file contents to katello.local.rb so we can run local tests
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_user_dir }}/foreman/bundler.d/katello.local.rb"
+    block: "{{ item.content | b64decode }}"
+  loop: "{{ found_file_contents.results }}"
+  when: katello_gemfile_dir.stat.exists and katello_local_rb_file.stat.exists
+
 - name: Remove .gitkeep file copied over from custom directory
   file:
     path: "{{ ansible_env.HOME }}/.gitkeep/"


### PR DESCRIPTION
This PR addresses [SAT-26017](https://issues.redhat.com/browse/SAT-26017), adding katello test gems to foreman's katello.local.rb on vagrant box provision if certain conditions are met.

**Considerations:**
As of now, `customize_home` is only called for katello-related boxes. I added checks for both the source dir and destination file existing just in case. They shouldn't kick in unless we decide to `customize_home` for non-katello boxes as well, but I figured it's better to be safe.

**Testing Steps:**

1. In the forklift dir, create a new katello-devel box and provision it. On completion, check the contents of `~/foreman/bundler.d/katello.local.rb`. It should a 'test' group similar to the following:
```
group :test do
  gem "vcr", "~> 6.1"
  gem 'theforeman-rubocop', '~> 0.0.6', require: false
end
```
2. Re-run the provisioning on this box without destroying. `~/foreman/bundler.d/katello.local.rb` should contain only one 'test' group.
3. Create a katello-devel-stable box. `~/foreman/bundler.d/katello.local.rb` should still contain a 'test' group.