### PR TITLE
Reapply "Use Puppet 8 in nightly pipelines"

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -105,7 +105,7 @@ installers:
     katello: 'nightly'
     candlepin: '4.4'
     pulpcore: 'nightly'
-    puppet: 7
+    puppet: 8
     boxes:
       - 'almalinux8'
       - 'almalinux9'


### PR DESCRIPTION
This reverts commit c86e8d8ad525d5a4d5c6b9fd711250cba0b599cc.

https://community.theforeman.org/t/puppet-8-support/33482/14 and beyond have more context. https://github.com/theforeman/foreman-installer/pull/953 should make this work now.