### PR TITLE
drop selinux workaround

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -13,14 +13,3 @@
   shell: rm -f /boot/*-generic.img
   when:
     - ansible_os_family == 'Debian'
-
-# workaround for broken libsemanage due to https://issues.redhat.com/browse/RHEL-55414
-- name: don't install broken libsemanage on EL9
-  community.general.ini_file:
-    path: /etc/dnf/dnf.conf
-    section: main
-    option: excludepkgs
-    value: 'libsemanage-3.6-2.*,python3-libsemanage-3.6-2.*'
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '9'

--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -27,9 +27,7 @@
 
 - name: force downgrade to libsemanage-3.6-1.el9.x86_64
   ansible.builtin.package:
-    name:
-      - libsemanage-3.6-1.el9.x86_64
-      - python3-libsemanage-3.6-1.el9.x86_64
+    name: libsemanage-3.6-1.el9.x86_64
     state: present
   when:
     - ansible_distribution == 'CentOS'

--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -24,11 +24,3 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == '9'
-
-- name: force downgrade to libsemanage-3.6-1.el9.x86_64
-  ansible.builtin.package:
-    name: libsemanage-3.6-1.el9.x86_64
-    state: present
-  when:
-    - ansible_distribution == 'CentOS'
-    - ansible_distribution_major_version == '9'


### PR DESCRIPTION
- **Revert "also downgrade python3-libsemanage explicitly"**
- **Revert "force downgrade to libsemanage-3.6-1.el9.x86_64"**
- **Revert "workaround for broken libsemanage on CentOS Stream 9"**

Needs https://kojihub.stream.centos.org/koji/buildinfo?buildID=68213 to land first
