### PR TITLE
Add CentOS Stream 9 provisioning using theforeman.foreman modules

### DIFF
--- a/playbooks/foreman_provisioning.yml
+++ b/playbooks/foreman_provisioning.yml
@@ -2,6 +2,12 @@
   become: true
   vars:
     libvirt_tftp: true
+  module_defaults:
+    group/theforeman.foreman.foreman:
+      username: admin
+      password: changeme
+      server_url: "https://localhost/"
+      validate_certs: false
   roles:
     - foreman
     - libvirt

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,7 @@
 collections:
+  - name: https://github.com/theforeman/foreman-ansible-modules.git
+    type: git
+  
   - name: https://github.com/theforeman/foreman-operations-collection
     type: git
 

--- a/roles/foreman_provisioning/tasks/configure_centos_9.yml
+++ b/roles/foreman_provisioning/tasks/configure_centos_9.yml
@@ -1,0 +1,21 @@
+- name: "Ensure CentOS Stream 9" # noqa: args[module]
+  theforeman.foreman.operatingsystem:
+    name: CentOS_Stream
+    family: Redhat
+    major: 9
+    architectures:
+      - x86_64
+    media:
+      - CentOS Stream 9 mirror
+    provisioning_templates:
+      - Kickstart default
+    ptables:
+      - Kickstart default
+    state: present
+
+- name: "Set default template for CentOS Stream 9" # noqa: args[module]
+  theforeman.foreman.os_default_template:
+    operatingsystem: "CentOS_Stream 9"
+    template_kind: "provision"
+    provisioning_template: "Kickstart default"
+    state: present

--- a/roles/foreman_provisioning/tasks/main.yml
+++ b/roles/foreman_provisioning/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: 'Setup CentOS 7 provisioning'
-  import_tasks: configure_centos_7.yml
+- name: 'Setup CentOS 9 provisioning'
+  import_tasks: configure_centos_9.yml
 
 - name: 'Setup Fedora 27 provisioning'
   import_tasks: configure_fedora_27.yml


### PR DESCRIPTION
This PR rewrite the CentOS Stream 9 provisioning tasks by replacing
Hammer CLI commands with [`theforeman.foreman`](https://github.com/theforeman/foreman-ansible-modules) modules.

For reference:  https://github.com/theforeman/forklift/pull/1832#discussion_r1680774786