### PR TITLE
Remove get_md5 parameter

### DIFF
--- a/roles/swapfile/tasks/main.yml
+++ b/roles/swapfile/tasks/main.yml
@@ -3,7 +3,6 @@
   stat:
     path: "{{ swapfile_path }}"
     get_checksum: False
-    get_md5: False
   register: swapfile_check
 
 - name: create swap file {{ swapfile_path }}


### PR DESCRIPTION
This was dropped at least in 2.17 and now triggers ansible-lint.