### PR TITLE
Add a bootc centos stream 9 host

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -46,3 +46,6 @@ boxes:
     scenarios:
       - foreman
       - katello
+
+  centos-stream9-bootc:
+    box_name: katello/centos-stream9-bootc


### PR DESCRIPTION
I built a base CentOS 9 Stream bootc host and uploaded it as a box to https://portal.cloud.hashicorp.com/services/vagrant/registries/katello/boxes/centos-stream9-bootc/versions/2025.0925.1700?project_id=08e72f3b-c08f-4707-a94b-96f7464fbf9a

It's exposed here in forklift. There are some caveats:
1) ~~I had to find the raw download link because Fedora's  current version of Vagrant doesn't seem to know how to connect to the new Vagrant registry in the Hashicorp cloud (https://app.daily.dev/posts/vagrant-cloud-is-moving-to-hcp-s6pzswzuc)~~
2) Bringing the machine up fails with `mkdir: cannot create directory ‘/vagrant’: Read-only file system` because `/` is read-only on bootc hosts.
  -> I tried disabling the syncing via `synced_folders` in the yaml file, but it was ignored. I'm curious if anyone has any other ideas for disabling the default rsyncing for a single host.