### PR TITLE
Revert "add test for container push on Katello 4.14+"

### DIFF
--- a/bats/fb-katello-container.bats
+++ b/bats/fb-katello-container.bats
@@ -13,13 +13,3 @@ load fixtures/content
   CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
   podman pull "${HOSTNAME}/${CONTAINER_PULL_LABEL}"
 }
-
-@test "push container to katello" {
-  tContainerPushSupported
-  tPackageExists podman || tPackageInstall podman
-  podman login "${HOSTNAME}" -u admin -p changeme
-  CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
-  CONTAINER_PUSH_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}-bats-$(date -u '+%s')"| tr '[:upper:]' '[:lower:]')
-  podman push "${HOSTNAME}/${CONTAINER_PULL_LABEL}" "${HOSTNAME}/${CONTAINER_PUSH_LABEL}"
-  podman search "${HOSTNAME}/" | grep -q "${CONTAINER_PUSH_LABEL}"
-}

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -46,13 +46,6 @@ tSkipIfOlderThan43() {
   fi
 }
 
-tContainerPushSupported() {
-  KATELLO_VERSION=$(tKatelloVersion)
-  if ! tIsVersionNewer "${KATELLO_VERSION}" 4.14; then
-    skip "Container push is only supported on Katello 4.14+"
-  fi
-}
-
 tIsPulp2() {
   tPackageExists pulp-server
 }


### PR DESCRIPTION
Reverts theforeman/forklift#1853

```
[root@centos9-stream-katello-nightly ~]# hammer organization create --name delete_test
Organization created.
[root@centos9-stream-katello-nightly ~]# hammer product create --name test_product --organization delete_test
Product created.
[root@centos9-stream-katello-nightly ~]# podman login "${HOSTNAME}" -u admin -p changeme
Login Succeeded!
[root@centos9-stream-katello-nightly ~]# podman push dc3bacd8b5ea centos9-stream-katello-nightly.tanso.example.com/delete_test/test_product/foremanbusybox
Getting image source signatures
Copying blob 8f8e3c7011ee done   | 
Copying config dc3bacd8b5 done   | 
Writing manifest to image destination
[root@centos9-stream-katello-nightly ~]# hammer organization delete --name delete_test
[........................                                                                                                                                                                                                       ] [11%]
Error: Error message: the server returns an error
HTTP status code: 405
Response headers: {"date"=>"Thu, 26 Sep 2024 17:35:33 GMT", "server"=>"gunicorn", "content-type"=>"application/json", "vary"=>"Accept,Cookie", "allow"=>"GET, PUT, PATCH, HEAD, OPTIONS", "x-frame-options"=>"DENY", "content-length"=>"43", "x-content-type-options"=>"nosniff", "referrer-policy"=>"same-origin", "cross-origin-opener-policy"=>"same-origin", "correlation-id"=>"b680e969-ffab-4a4a-b2f3-d083dc9e185a", "access-control-expose-headers"=>"Correlation-ID", "via"=>"1.1 centos9-stream-katello-nightly.tanso.example.com"}
Response body: {"detail":"Method \"DELETE\" not allowed."}
```