### PR TITLE
Revert "use ansible_default_ipv4 if possible when writing /etc/hosts"

### DIFF
--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -3,7 +3,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: ".*{{ item.replace('.', '-') }}$"
-    line: "{{ ansible_default_ipv4['address'] | default(hostvars[item].ansible_host) }} {{ item.replace('.', '-') }}.{{ etc_hosts_domain }} {{ item.replace('.', '-') }}"
+    line: "{{ hostvars[item].ansible_host }} {{ item.replace('.', '-') }}.{{ etc_hosts_domain }} {{ item.replace('.', '-') }}"
     state: present
   when: hostvars[item].ansible_host is defined
   become: yes

--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -190,7 +190,6 @@ module Forklift
 
       [playbooks].flatten.each_with_index do |playbook, index|
         machine.vm.provision("main#{index}", type: 'ansible') do |ansible_provisioner|
-          ansible_provisioner.compatibility_mode = '2.0'
           ansible_provisioner.playbook = playbook
           ansible_provisioner.extra_vars = ansible['variables']
           ansible_provisioner.groups = @ansible_groups


### PR DESCRIPTION
Reverts theforeman/forklift#1854

This broke multi-host deployments.