### PR TITLE
Attempt to fix container search bats issue with a delay

### DIFF
--- a/bats/fb-katello-container.bats
+++ b/bats/fb-katello-container.bats
@@ -21,5 +21,9 @@ load fixtures/content
   CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
   CONTAINER_PUSH_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}-bats-$(date -u '+%s')"| tr '[:upper:]' '[:lower:]')
   podman push "${HOSTNAME}/${CONTAINER_PULL_LABEL}" "${HOSTNAME}/${CONTAINER_PUSH_LABEL}"
+  # Sleep for 5 seconds due to an intermittent issue where pushed content
+  # is not immediately searchable via podman search.
+  # See https://github.com/theforeman/forklift/pull/1864 for more information.
+  sleep 5
   podman search "${HOSTNAME}/" | grep -q "${CONTAINER_PUSH_LABEL}"
 }


### PR DESCRIPTION
5 seconds should be adequate. If it's not the case, then we likely have a podman push bug somewhere.