### PR TITLE
also add Debian 12 to 3.11 and 3.12

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -41,6 +41,7 @@ installers:
       - 'almalinux9'
       - 'centos9-stream'
       - 'debian11'
+      - 'debian12'
       - 'ubuntu2004'
       - 'ubuntu2204'
 
@@ -54,6 +55,7 @@ installers:
       - 'almalinux9'
       - 'centos9-stream'
       - 'debian11'
+      - 'debian12'
       - 'ubuntu2004'
       - 'ubuntu2204'
 


### PR DESCRIPTION
while we don't officially support these on Debian 12 (yet?), this allows
running upgrade pipelines on Debian 12 already
