### PR TITLE
Become root in foreman_proxy_content role to add group

### DIFF
--- a/playbooks/foreman_proxy_content_dev.yml
+++ b/playbooks/foreman_proxy_content_dev.yml
@@ -14,6 +14,7 @@
     - role: foreman_proxy_content
       foreman_directory: "{{ ansible_user_dir }}/foreman/config/"
       devel: true
+      become: true
       base_foreman_directory: "{{ ansible_user_dir }}/foreman/"
     - role: foreman_installer
       become: true


### PR DESCRIPTION
Fixes an error when provisioning a proxy content devel box where the vagrant user was trying to add the foreman group.