### PR TITLE
Use the Hashicorp cloud again for CentOS boxes

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -2,8 +2,6 @@ boxes:
   centos9-stream:
     box_name: 'centos/stream9'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box
-    virtualbox: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-virtualbox.box
     scenarios:
       - foreman
       - katello
@@ -11,8 +9,6 @@ boxes:
   centos10-stream:
     box_name: 'centos/stream10'
     disk_size: 40
-    libvirt: https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-libvirt.box
-    virtualbox: https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-virtualbox.box
     scenarios:
       - foreman
       - katello


### PR DESCRIPTION
These have been updated and work again. Because Vagrant understands the versions, they can be easily updated.