### PR TITLE
Use newer container naming in container BATS

### DIFF
--- a/bats/fb-katello-container.bats
+++ b/bats/fb-katello-container.bats
@@ -10,7 +10,11 @@ load fixtures/content
 @test "try fetching container content" {
   tPackageExists podman || tPackageInstall podman
   podman login "${HOSTNAME}" -u admin -p changeme
-  CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  if tIsVersionNewer "${KATELLO_VERSION}" 4.16; then
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  else
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  fi
   podman pull "${HOSTNAME}/${CONTAINER_PULL_LABEL}"
 }
 
@@ -19,7 +23,11 @@ load fixtures/content
   tContainerPushSupported
   tPackageExists podman || tPackageInstall podman
   podman login "${HOSTNAME}" -u admin -p changeme
-  CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  if tIsVersionNewer "${KATELLO_VERSION}" 4.16; then
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  else
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  fi 
   CONTAINER_PUSH_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}-bats-$(date -u '+%s')"| tr '[:upper:]' '[:lower:]')
   podman push "${HOSTNAME}/${CONTAINER_PULL_LABEL}" "${HOSTNAME}/${CONTAINER_PUSH_LABEL}"
   # Sleep for 5 seconds due to an intermittent issue where pushed content

--- a/bats/foreman_helper.bash
+++ b/bats/foreman_helper.bash
@@ -48,8 +48,8 @@ tSkipIfOlderThan43() {
 
 tContainerPushSupported() {
   KATELLO_VERSION=$(tKatelloVersion)
-  if ! tIsVersionNewer "${KATELLO_VERSION}" 4.15; then
-    skip "Container push is only supported on Katello 4.15+"
+  if ! tIsVersionNewer "${KATELLO_VERSION}" 4.14; then
+    skip "Container push is only supported on Katello 4.14+"
   fi
 }
 


### PR DESCRIPTION
Since container repos now have slashes in them, the test needs updating.

I also updated the version requirement for the container push test since it should run on Katello 4.14. (It still needs investigation though :) )

I haven't been able to actually test this yet due to issues running the pipeline locally.