### PR TITLE
Drop almalinux8 boxes for 3.13 & nightly

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -65,7 +65,6 @@ installers:
     pulpcore: '3.63'
     puppet: 8
     boxes:
-      - 'almalinux8'
       - 'almalinux9'
       - 'centos9-stream'
       - 'debian11'
@@ -78,7 +77,6 @@ installers:
     pulpcore: 'nightly'
     puppet: 8
     boxes:
-      - 'almalinux8'
       - 'almalinux9'
       - 'centos9-stream'
       - 'debian11'


### PR DESCRIPTION
We've dropped EL8 and these boxes should no longer be generated.