### PR TITLE
Check for Katello version properly for container tests

### DIFF
--- a/bats/fb-katello-client-global-registration.bats
+++ b/bats/fb-katello-client-global-registration.bats
@@ -77,7 +77,11 @@ load fixtures/content
 @test "try fetching container content" {
   tPackageExists podman || tPackageInstall podman
   podman login "${HOSTNAME}" -u admin -p changeme
-  CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  if tIsVersionNewer "$(tKatelloVersion)" 4.16; then
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  else
+    CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
+  fi
   podman pull "${HOSTNAME}/${CONTAINER_PULL_LABEL}"
 }
 

--- a/bats/fb-katello-container.bats
+++ b/bats/fb-katello-container.bats
@@ -10,7 +10,7 @@ load fixtures/content
 @test "try fetching container content" {
   tPackageExists podman || tPackageInstall podman
   podman login "${HOSTNAME}" -u admin -p changeme
-  if tIsVersionNewer "${KATELLO_VERSION}" 4.16; then
+  if tIsVersionNewer "$(tKatelloVersion)" 4.16; then
     CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
   else
     CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
@@ -23,7 +23,7 @@ load fixtures/content
   tContainerPushSupported
   tPackageExists podman || tPackageInstall podman
   podman login "${HOSTNAME}" -u admin -p changeme
-  if tIsVersionNewer "${KATELLO_VERSION}" 4.16; then
+  if tIsVersionNewer "$(tKatelloVersion)" 4.16; then
     CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}/${PRODUCT_LABEL}/${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')
   else
     CONTAINER_PULL_LABEL=$(echo "${ORGANIZATION_LABEL}-${PRODUCT_LABEL}-${CONTAINER_REPOSITORY_LABEL}"| tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
`$(tKatelloVersion)` replaces the undefined KATELLO_VERSION used in the tests previously.

Also updates the container tests in the client test file.