### PR TITLE
Drop ruby_libvirt_gem role

### DIFF
--- a/roles/foreman_provisioning/meta/main.yml
+++ b/roles/foreman_provisioning/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 dependencies:
   - role: hammer_credentials
-  - role: ruby_libvirt_gem
   - role: foreman_installer
     foreman_installer_scenario: "{{ foreman_provisioning_scenario }}"
     foreman_installer_options:

--- a/roles/ruby_libvirt_gem/handlers/main.yml
+++ b/roles/ruby_libvirt_gem/handlers/main.yml
@@ -1,5 +1,0 @@
----
-- name: 'Restart smart proxy'
-  service:
-    name: foreman-proxy
-    state: restarted

--- a/roles/ruby_libvirt_gem/tasks/main.yml
+++ b/roles/ruby_libvirt_gem/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: 'Install libvirt gem'
-  yum:
-    name: rubygem-ruby-libvirt
-    state: present
-  notify:
-    - 'Restart smart proxy'


### PR DESCRIPTION
Since Foreman 2.0.2 the foreman-proxy package has depended on the libvirt gem so this isn't needed anymore.

Link: https://projects.theforeman.org/issues/30040