### PR TITLE
use a login shell when using become for bats

### DIFF
--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -43,6 +43,7 @@
       register: "test_output"
       ignore_errors: true
       environment: "{{ bats_environment }}"
+      # Adds -i to Ansible's default
       become_flags: '-H -S -n -i'
 
     - name: "Read results"

--- a/roles/bats/tasks/main.yml
+++ b/roles/bats/tasks/main.yml
@@ -43,6 +43,7 @@
       register: "test_output"
       ignore_errors: true
       environment: "{{ bats_environment }}"
+      become_flags: '-H -S -n -i'
 
     - name: "Read results"
       shell: "cat {{ bats_output_dir }}/{{ item }}.tap"


### PR DESCRIPTION
otherwise the puppet path (/opt/puppetlabs/bin) is not loaded and tests
fail to call puppetserver
