### PR TITLE
force Vagrant to use the "new" API URL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 
 ENV['LANG'] = 'en_US.UTF-8'
 ENV['LC_ALL'] = 'en_US.UTF-8'
+ENV['VAGRANT_SERVER_URL'] ||= 'https://vagrantcloud.com/api/v2/vagrant'
 VAGRANTFILE_DIR = File.dirname(__FILE__)
 
 require "#{VAGRANTFILE_DIR}/vagrant/lib/forklift"


### PR DESCRIPTION
It seems Vagrant has introduced a new API and their proprietary client
does use that by default now, so they turned off the old one (or the
redirect, I really have no idea what was there last week).

Just setting the new URL (which I found out by using `vagrant --debug`)
as the server URL works for now, so let's do that, and at least unblock
nightlies.
