### PR TITLE
Fix freeipa_server role

### DIFF
--- a/roles/freeipa_server/tasks/install_freeipa_server.yml
+++ b/roles/freeipa_server/tasks/install_freeipa_server.yml
@@ -29,4 +29,6 @@
 - name: 'Run FreeIPA Install'
   become: true
   shell:
-    cmd: ipa-server-install -U -r {{ freeipa_server_realm }} -p {{ freeipa_server_directory_manager_password }} -a {{ freeipa_server_directory_admin_password }} creates=/etc/krb5.keytab
+    cmd: ipa-server-install -U -r {{ freeipa_server_realm }} -p {{ freeipa_server_directory_manager_password }} -a {{ freeipa_server_directory_admin_password }}
+  args:
+    creates: /etc/krb5.keytab

--- a/roles/freeipa_server/tasks/main.yml
+++ b/roles/freeipa_server/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - include_tasks: install_freeipa_server.yml
 - include_tasks: install_freeipa_client.yml
+  when: katello_server_origin is defined


### PR DESCRIPTION
Server installation should now pass. Client installation is only run when katello_server_origin is defined.