### PR TITLE
Start rhsmcertd after sub-man registers in BATS

### DIFF
--- a/bats/fb-katello-client-global-registration.bats
+++ b/bats/fb-katello-client-global-registration.bats
@@ -47,6 +47,8 @@ load fixtures/content
 
   registration_command=$(echo "${registration_json}" | ruby -e "require 'json'; puts JSON.load(ARGF.read).fetch('registration_command')")
   eval "${registration_command}"
+  # Remove after subscription-manager 1.29.46 is released
+  systemctl start rhsmcertd
   tSubscribedProductOrSCA "${PRODUCT}"
 }
 

--- a/bats/fb-katello-client-katello-agent.bats
+++ b/bats/fb-katello-client-katello-agent.bats
@@ -36,6 +36,8 @@ setup() {
   tPackageInstall http://localhost/pub/katello-ca-consumer-latest.noarch.rpm
   echo "rc=${status}"
   echo "${output}"
+  # Remove after subscription-manager 1.29.46 is released
+  systemctl start rhsmcertd
   subscription-manager register --force --org="${ORGANIZATION_LABEL}" --username=admin --password=changeme --env=Library
 }
 

--- a/bats/fb-katello-client-rex.bats
+++ b/bats/fb-katello-client-rex.bats
@@ -30,6 +30,8 @@ load fixtures/content
   tPackageInstall http://localhost/pub/katello-ca-consumer-latest.noarch.rpm
   echo "rc=${status}"
   echo "${output}"
+  # Remove after subscription-manager 1.29.46 is released
+  systemctl start rhsmcertd
   subscription-manager register --force --org="${ORGANIZATION_LABEL}" --username=admin --password=changeme --env=Library
 }
 


### PR DESCRIPTION
subscription-manager is no longer sending package profiles without rhsmcertd as of `1.29.45`.

By default, the service is dead until the system is rebooted. This should theoretically fix the current failing errata tests.

Also, I deleted the katello-agent tests since it's very gone by now.