### PR TITLE
Add centos9-hammer-devel box

### DIFF
--- a/playbooks/hammer_devel.yml
+++ b/playbooks/hammer_devel.yml
@@ -3,6 +3,4 @@
   roles:
     - etc_hosts
     - git
-    - role: ruby_scl
-      become: yes
     - hammer_devel

--- a/roles/hammer_devel/defaults/main.yml
+++ b/roles/hammer_devel/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-hammer_devel_ruby_version: 2.3.1
 hammer_devel_server_group: "server-{{ inventory_hostname }}"
 hammer_devel_server: "centos9-katello-devel"
 hammer_devel_server_protocol: 'https'

--- a/roles/hammer_devel/tasks/hammer_install.yml
+++ b/roles/hammer_devel/tasks/hammer_install.yml
@@ -1,4 +1,13 @@
 ---
+- name: 'Install Ruby'
+  yum:
+    name:
+      - "ruby"
+      - "ruby-devel"
+      - "rubygem-bundler"
+    state: present
+  become: true
+
 - name: 'Clone the hammer repositories'
   git:
     repo: https://github.com/{{ item }}.git
@@ -56,3 +65,4 @@
   bundler:
     chdir: '~/hammer-cli-foreman'
     state: present
+    gem_path: '~/hammer-cli-foreman/.vendor'

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -39,14 +39,15 @@ almalinux8-luna-demo:
   ansible:
     playbook: playbooks/luna_demo_environment.yml
 
-almalinux8-hammer-devel:
-  box: almalinux8
-  memory: 512
+centos9-hammer-devel:
+  box: centos9-stream
+  memory: 2048
   ansible:
     playbook: 'playbooks/hammer_devel.yml'
     group: 'hammer-devel'
     variables: # defaults in roles/hammer_devel/defaults/main.yml
-      #hammer_devel_server: almalinux8-katello-devel.custom-domain.example.com
+      hammer_devel_github_username: <REPLACE ME>
+      hammer_devel_server: centos9-katello-devel-stable.example.com
 
 centos9-proxy-devel:
     box: centos9-stream


### PR DESCRIPTION
Adds a centos9-hammer-devel box. Updates the old SCL bits to work on EL9.