### PR TITLE
Reapply "Force Ansible 2.x compatiblity mode in Vagrant"

### DIFF
--- a/vagrant/lib/forklift/box_distributor.rb
+++ b/vagrant/lib/forklift/box_distributor.rb
@@ -190,6 +190,7 @@ module Forklift
 
       [playbooks].flatten.each_with_index do |playbook, index|
         machine.vm.provision("main#{index}", type: 'ansible') do |ansible_provisioner|
+          ansible_provisioner.compatibility_mode = '2.0'
           ansible_provisioner.playbook = playbook
           ansible_provisioner.extra_vars = ansible['variables']
           ansible_provisioner.groups = @ansible_groups


### PR DESCRIPTION
This reverts commit 3334f60336b561654b7927d70df10e6de14ef2a2.

The "Force Ansible 2.x" was originally part of #1854, but that got reverted as it broke things.
Later, #1875 did the broken part correctly, but forgot to re-apply the Ansible compat mode part.

This should fix VirtualBox deployments.