### PR TITLE
use "sos report", not "sosreport" to generate a sos report

### DIFF
--- a/roles/sos_report/tasks/main.yml
+++ b/roles/sos_report/tasks/main.yml
@@ -8,7 +8,7 @@
     state: present
 
 - name: 'Generate sosreport'
-  command: "sosreport --batch --tmp-dir={{ sosreport_output_dir }}"
+  command: "sos report --batch --tmp-dir={{ sosreport_output_dir }}"
   ignore_errors: true
 
 - include_tasks: 'sosreport_fetch_results.yml'


### PR DESCRIPTION
On EL9, calling `sosreport` just prints
```
sosreport binary is deprecated, use 'sos report' instead
```
And doesn't generate any report.

Using `sos report` as suggested works, and that also works on Debian
(where calling `sosreport` still works -- with a deprecation warning).
