### PR TITLE
Automate building the Katello stable box and uploading it to Vagrant Cloud

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -10,9 +10,13 @@ You can install packer using [the steps in their documentation](https://develope
 
 From this directory, use `packer build` followed by the json packer template to create an image
 
-For example: `packer build centos9-katello-devel-stable.json`
+To also upload a new box, you will need the client ID and client secret for the stablebox-creator service principal. You can find that in the Access control section of the katello-devel project in the Hashicorp Cloud.
 
-You can create a box image using the above command and then add that box to Vagrant:
+To build a new box, run: `HCP_CLIENT_ID=id HCP_CLIENT_SECRET=secret packer build -var "version=2025.0606.1303" centos9-katello-devel-stable.json`
+
+Increment the version using the current date: `date +%Y.%m%d.%H%M`
+
+The above command  will create a box and then you can add that box to Vagrant locally to test:
 
 ```sh
 vagrant box add --name centos9-katello-devel-stable centos9-katello-devel-stable.box

--- a/packer/centos9-katello-devel-stable.json
+++ b/packer/centos9-katello-devel-stable.json
@@ -16,7 +16,7 @@
       "format": "qcow2",
       "headless": true,
       "http_directory": "http",
-      "iso_checksum": "sha256:62318426d27ba4e255b509b033e78186ad0fb8b9007650fca73d226ceb2eda6f",
+      "iso_checksum": "file:https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-boot.iso.SHA256SUM",
       "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-boot.iso",
       "name": "{{ user `packer_hostname` }}.example.com",
       "qemuargs": [
@@ -41,11 +41,19 @@
     }
   ],
   "post-processors": [
-    {
-      "keep_input_artifact": false,
-      "output": "{{user `packer_hostname`}}.box",
-      "type": "vagrant"
-    }
+    [
+      {
+        "keep_input_artifact": false,
+        "output": "{{user `packer_hostname`}}.box",
+        "type": "vagrant"
+      },
+      {
+        "type": "vagrant-registry",
+        "box_tag": "katello/katello-devel",
+        "version": "{{user `version`}}",
+        "architecture": "amd64"
+      }
+    ]
   ],
   "provisioners": [
     {


### PR DESCRIPTION
- Fetches the base ISO checksum instead of hard-coding it.
- Adds the vagrant-registry post processor to upload the box after building it
- Updates the README