### PR TITLE
verify SELinux for Katello 4.18+ and Luna when doing installs

### DIFF
--- a/pipelines/vars/forklift_katello.yml
+++ b/pipelines/vars/forklift_katello.yml
@@ -16,6 +16,7 @@ server_box:
       bats_tests_additional:
         - fb-katello-proxy.bats
         - "{{ 'fb-test-katello-change-hostname.bats' if pipeline_action == 'install' else ''}}"
+        - "{{ 'fb-verify-selinux.bats' if (pipeline_action == 'install' and (pipeline_version == 'nightly' or pipeline_version is version('4.18', '>='))) else ''}}"
 proxy_box:
   box: "{{ pipeline_proxy_os | default(pipeline_os) }}"
   memory: 3072

--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -68,6 +68,7 @@ server_box:
         - "fb-test-foreman-templates.bats"
         - "fb-katello-proxy.bats"
         - "{{ 'fb-test-katello-change-hostname.bats' if pipeline_action == 'install' else ''}}"
+        - "{{ 'fb-verify-selinux.bats' if pipeline_action == 'install' else ''}}"
 proxy_box:
   box: "{{ pipeline_proxy_os | default(pipeline_os) }}"
   memory: 3072

--- a/roles/foreman_devel/tasks/rhel.yml
+++ b/roles/foreman_devel/tasks/rhel.yml
@@ -18,7 +18,7 @@
 - name: "Enable only RHEL7 base + optional + extras repos"
   rhsm_repository:
     name: "{{ item }}"
-    state: "present"
+    state: "enabled"
   become: true
   with_items:
       - rhel-7-server-rpms

--- a/roles/forklift_versions/molecule/default/verify.yml
+++ b/roles/forklift_versions/molecule/default/verify.yml
@@ -16,7 +16,7 @@
         scenario: "{{ pipeline_type }}"
         scenario_os: "{{ pipeline_os }}"
         scenario_version: "4.12"
-    - name: Ensure versions have been set correctly
+    - name: Ensure versions have been set correctly for 4.12
       assert:
         that:
           - foreman_repositories_version == '3.10'
@@ -31,7 +31,7 @@
         scenario: "{{ pipeline_type }}"
         scenario_os: "{{ pipeline_os }}"
         scenario_version: "nightly"
-    - name: Ensure versions have been set correctly
+    - name: Ensure versions have been set correctly for nightly
       assert:
         that:
           - foreman_repositories_version is defined
@@ -47,7 +47,7 @@
         scenario_os: "{{ pipeline_os }}"
         scenario_version: "4.13"
         upgrade: True
-    - name: Ensure upgrade steps have been determined correctly
+    - name: Ensure upgrade steps have been determined correctly for 4.13
       assert:
         that:
           - forklift_upgrade_version_start == '4.12'
@@ -63,7 +63,7 @@
         scenario_version: "4.14"
         upgrade: True
         upgrade_step: 2
-    - name: Ensure upgrade steps have been determined correctly
+    - name: Ensure upgrade steps have been determined correctly for 4.14
       assert:
         that:
           - forklift_upgrade_version_start == '4.10'


### PR DESCRIPTION
- install only as upgrades still have SELinux issues in the logs from previous releases
- nightly/4.18+ only, as the fixes are not yet in stable releases