### PR TITLE
Add hammer-rh-cloud and add devel CA cert to hammer devel box

### DIFF
--- a/roles/hammer_devel/defaults/main.yml
+++ b/roles/hammer_devel/defaults/main.yml
@@ -14,6 +14,7 @@ hammer_devel_repositories:
   - theforeman/hammer-cli-foreman-tasks
   - theforeman/hammer_cli_foreman_remote_execution
   - theforeman/hammer-cli-foreman-virt-who-configure
+  - theforeman/hammer-cli-foreman-rh-cloud
   - katello/hammer-cli-csv
   - katello/hammer-cli-katello
 hammer_devel_local_gems: |-
@@ -23,4 +24,5 @@ hammer_devel_local_gems: |-
     gem 'hammer_cli_foreman_tasks'
     gem 'hammer_cli_foreman_remote_execution'
     gem 'hammer_cli_foreman_virt_who_configure'
+    gem 'hammer_cli_foreman_rh_cloud'
     gem 'hammer_cli_csv'

--- a/roles/hammer_devel/tasks/hammer_config.yml
+++ b/roles/hammer_devel/tasks/hammer_config.yml
@@ -88,3 +88,15 @@
   lineinfile:
     dest: '~/.bash_profile'
     line: "alias rake='bundle exec rake'"
+
+- name: 'Attempt to get CA certificate from devel server'
+  block:
+    - name: 'Execute command to fetch cert'
+      command: "bundle exec hammer --fetch-ca-cert {{ hammer_devel_host }}"
+      args:
+        chdir: '~/hammer-cli-foreman'
+
+  rescue:
+    - name: 'Report failure to get cert if devel box is not running'
+      debug:
+        msg: "Cert retrieval from {{ hammer_devel_host }} failed. The devel box was likely not running. Please run hammer --fetch-ca-cert {{ hammer_devel_host }} manually."


### PR DESCRIPTION
When trying to grab the ca cert from a box that is not valid or up:
```
TASK [hammer_devel : Execute command to fetch cert] *************************************************************************************************************************************************************
fatal: [ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com]: FAILED! => changed=true
  cmd:
  - bundle
  - exec
  - hammer
  - --fetch-ca-cert
  - https://centos9-katello-devel:443
  delta: '0:00:00.734307'
  end: '2025-09-24 09:41:17.450048'
  msg: non-zero return code
  rc: 70
  start: '2025-09-24 09:41:16.715741'
  stderr: |-
    WARNING: File locale/bn/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/bqi/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/de/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/en_GB/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/ro/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/zh/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    WARNING: File locale/zh_TW/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
    Fetching the CA certificate failed:
    getaddrinfo: Name or service not known
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
 [started TASK: hammer_devel : Report failure to get cert if devel box is not running on ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com]

TASK [hammer_devel : Report failure to get cert if devel box is not running] ************************************************************************************************************************************
ok: [ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com] =>
  msg: Cert retrieval from https://centos9-katello-devel:443 failed. The devel box was likely not running and the certificate will need to be ran manually later.

PLAY RECAP ******************************************************************************************************************************************************************************************************
ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com : ok=29   changed=1    unreachable=0    failed=0    skipped=1    rescued=1    ignored=3
```
A working box:
```
TASK [hammer_devel : Execute command to fetch cert] *************************************************************************************************************************************************************
changed: [ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com]

PLAY RECAP ******************************************************************************************************************************************************************************************************
ip-10-0-168-28.rhos-01.prod.psi.rdu2.redhat.com : ok=29   changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=3
```