### PR TITLE
do not install nokogiri from pvalena/rubygems

### DIFF
--- a/playbooks/setup_forklift.yml
+++ b/playbooks/setup_forklift.yml
@@ -4,9 +4,9 @@
   vars:
     vagrant_libvirt: true
   roles:
+    - role: epel_repositories
     - role: libvirt
     - role: vagrant
-    - role: epel_repositories
 
 - hosts: all
   vars:

--- a/roles/vagrant/tasks/main.yml
+++ b/roles/vagrant/tasks/main.yml
@@ -14,6 +14,11 @@
     url: https://copr.fedorainfracloud.org/coprs/evgeni/vagrant/repo/epel-{{ ansible_distribution_major_version }}/evgeni-vagrant-epel-{{ ansible_distribution_major_version }}.repo
     dest: /etc/yum.repos.d/evgeni-vagrant.repo
 
+- name: 'do not install nokogiri from pvalena/rubygems'
+  lineinfile:
+    path: /etc/yum.repos.d/pvalena-rubygems.repo
+    line: 'exclude=rubygem-nokogiri*'
+
 - name: 'install vagrant'
   package:
     name: vagrant


### PR DESCRIPTION
pvalena/rubygems ships nokogiri 1.18(.10), which requires Ruby 3.1+[1], but on EL9 we're still using Ruby 3.0 by default.

Because of that, vagrant-libvirt (which requires nokogiri) fails to load:

    NoMethodError: undefined method `request' for nil:NilClass
    from /usr/share/rubygems/rubygems/resolver/conflict.rb:47:in `conflicting_dependencies'
    Caused by Gem::Resolver::Molinillo::VersionConflict: Unable to satisfy the following requirements:

    - `nokogiri (~> 1.6)` required by `vagrant-libvirt-0.12.2` from /usr/share/rubygems/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:317:in `raise_error_unless_state'

And that breaks vagrant and thus our pipelines.

Luckilly, EPEL has an EL9/Ruby3 compatible nokogiri, which we can use instead.

[1] https://github.com/sparklemotion/nokogiri/commit/5c4e7be0346aa2c8825eb8b7dc3c1252d8e4ca78