### PR TITLE
Foreman 3.19 branching

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -126,6 +126,17 @@ installers:
       - 'debian12'
       - 'ubuntu2204'
 
+  - foreman: '3.19'
+    katello: '4.21'
+    candlepin: '4.7'
+    pulpcore: '3.105'
+    puppet: 8
+    boxes:
+      - 'almalinux9'
+      - 'centos9-stream'
+      - 'debian12'
+      - 'ubuntu2204'
+
   - foreman: 'nightly'
     katello: 'nightly'
     candlepin: '4.7'


### PR DESCRIPTION
Pulpcore 3.105 is not built outside of nightly at the moment. 

**Do not merge it before packaging has been branched**
