### PR TITLE
make custom_hiera enablement compatible with Ansible 2.19+

### DIFF
--- a/roles/foreman_installer/defaults/main.yml
+++ b/roles/foreman_installer/defaults/main.yml
@@ -7,7 +7,7 @@ foreman_installer_scenario: foreman
 foreman_installer_scenario_flag: '{{ "--scenario" if foreman_installer_scenario else "" }}'
 foreman_installer_upgrade: False
 foreman_installer_command: foreman-installer
-foreman_installer_custom_hiera:
+foreman_installer_custom_hiera: ""
 foreman_installer_no_colors: True
 foreman_installer_disable_system_checks: False
 

--- a/roles/foreman_installer/tasks/main.yml
+++ b/roles/foreman_installer/tasks/main.yml
@@ -8,7 +8,7 @@
   when: (foreman_installer_module_prs|length > 0) or (foreman_installer_module_branches|length > 0)
 
 - include_tasks: custom_hiera.yml
-  when: foreman_installer_custom_hiera
+  when: foreman_installer_custom_hiera | length > 0
 
 - include_tasks: install.yml
   when: not foreman_installer_upgrade


### PR DESCRIPTION
This fixes the following error:

    [ERROR]: Task failed: Conditional result (False) was derived from value of type 'NoneType' at '<unknown>'. Conditionals must have a boolean result.

    Task failed.
    Origin: /home/evgeni/Devel/theforeman/forklift/roles/foreman_installer/tasks/main.yml:10:3

     8   when: (foreman_installer_module_prs|length > 0) or (foreman_installer_module_branches|length > 0)
     9
    10 - include_tasks: custom_hiera.yml
         ^ column 3

    <<< caused by >>>

    Conditional result (False) was derived from value of type 'NoneType' at '<unknown>'. Conditionals must have a boolean result.
    Origin: /home/evgeni/Devel/theforeman/forklift/roles/foreman_installer/tasks/main.yml:11:9

     9
    10 - include_tasks: custom_hiera.yml
    11   when: foreman_installer_custom_hiera
               ^ column 9

    Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.