### PR TITLE
Fixes #39330 - Update bats test for removed CV/LCE activation key params

### DIFF
--- a/bats/fb-katello-content.bats
+++ b/bats/fb-katello-content.bats
@@ -253,7 +253,7 @@ setup() {
 
 @test "create activation key" {
   hammer activation-key create --organization="${ORGANIZATION}" \
-    --name="${ACTIVATION_KEY}" --content-view="${CONTENT_VIEW}" --lifecycle-environment="${LIFECYCLE_ENVIRONMENT}" \
+    --name="${ACTIVATION_KEY}" --content-view-environments="${LIFECYCLE_ENVIRONMENT}/${CONTENT_VIEW}" \
     --unlimited-hosts | grep -q "Activation key created"
 }
 


### PR DESCRIPTION
## Summary

- Replace deprecated `--content-view` and `--lifecycle-environment` flags in `hammer activation-key create` with the new `--content-view-environments="LCE/CV"` format
- Follows the Katello change that removed backward-compat params for separate CV/LCE fields (Katello/katello#11753)

## Test plan

- [ ] Run the `fb-katello-content` bats pipeline and confirm the "create activation key" test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)