### PR TITLE
Increase smoker VM memory from 2GB to 4GB

### DIFF
--- a/pipelines/vars/install_base.yml
+++ b/pipelines/vars/install_base.yml
@@ -5,5 +5,5 @@ forklift_proxy_name: "pipe-{{ pipeline_type }}-proxy-{{ pipeline_version }}-{{ p
 forklift_smoker_name: "pipe-{{ pipeline_type }}-smoker-{{ pipeline_version }}-{{ pipeline_os }}"
 smoker_box:
   box: centos9-stream
-  memory: 2048
+  memory: 4096
 bats_test_name_prefix: "{{ pipeline_os }} {{ pipeline_action }}: "

--- a/pipelines/vars/upgrade_base.yml
+++ b/pipelines/vars/upgrade_base.yml
@@ -6,5 +6,5 @@ forklift_smoker_name: "pipe-up-{{ pipeline_type }}-smoker-{{ pipeline_version }}
 forklift_boxes: "{{ {forklift_server_name: server_box, forklift_smoker_name: smoker_box} }}"
 smoker_box:
   box: centos9-stream
-  memory: 2048
+  memory: 4096
 bats_test_name_prefix: "{{ pipeline_os }} {{ pipeline_action }}: "


### PR DESCRIPTION
## Summary
- Increase smoker VM memory from 2048MB to 4096MB in both install and upgrade pipeline vars
- Addresses intermittent Selenium `ReadTimeoutError` failures where chromedriver becomes unresponsive late in the smoker test run

## Context

Smoker tests run 78 UI tests with 2 parallel Chrome instances (`-n 2` via pytest-xdist). With only 2GB RAM, the VM runs out of resources after ~50-55 minutes of Chrome process churn, causing chromedriver to hang and the 120s urllib3 read timeout to fire on random `test_menu_item` pages.

Analysis across multiple failure logs showed this hitting every OS (AlmaLinux 9, CentOS 9 Stream), version (nightly, 4.20, 4.21), and pipeline type (install, upgrade) — always late in the run (85-98% complete), always on random pages.

See theforeman/smoker#48 for the full investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)