### PR TITLE
Remove hammer-cli-virt-who from forklift.

### DIFF
--- a/pipelines/vars/forklift_luna.yml
+++ b/pipelines/vars/forklift_luna.yml
@@ -55,7 +55,6 @@ server_box:
         - "--enable-foreman-cli-templates"
         - "--enable-foreman-plugin-templates"
 
-        - "--enable-foreman-cli-virt-who-configure"
         - "--enable-foreman-plugin-virt-who-configure"
 
         - "--enable-foreman-cli-webhooks"

--- a/playbooks/luna.yml
+++ b/playbooks/luna.yml
@@ -14,7 +14,6 @@
       - "--enable-foreman-cli-rh-cloud"
       - "--enable-foreman-cli-tasks"
       - "--enable-foreman-cli-templates"
-      - "--enable-foreman-cli-virt-who-configure"
       - "--enable-foreman-cli-webhooks"
       - "--enable-foreman-plugin-ansible"
       - "--enable-foreman-plugin-azure"

--- a/roles/hammer_devel/defaults/main.yml
+++ b/roles/hammer_devel/defaults/main.yml
@@ -12,7 +12,6 @@ hammer_devel_repositories:
   - theforeman/hammer-cli-foreman
   - theforeman/hammer-cli-foreman-tasks
   - theforeman/hammer_cli_foreman_remote_execution
-  - theforeman/hammer-cli-foreman-virt-who-configure
   - theforeman/hammer-cli-foreman-rh-cloud
   - katello/hammer-cli-csv
   - katello/hammer-cli-katello
@@ -21,6 +20,5 @@ hammer_devel_local_gems: |-
     gem 'hammer_cli_katello'
     gem 'hammer_cli_foreman_tasks'
     gem 'hammer_cli_foreman_remote_execution'
-    gem 'hammer_cli_foreman_virt_who_configure'
     gem 'hammer_cli_foreman_rh_cloud'
     gem 'hammer_cli_csv'

--- a/roles/hammer_devel/tasks/hammer_config.yml
+++ b/roles/hammer_devel/tasks/hammer_config.yml
@@ -73,12 +73,6 @@
     creates: ~/.hammer/cli.modules.d/foreman_remote_execution.yml
   when: ('theforeman/hammer_cli_foreman_remote_execution' in hammer_devel_repositories)
 
-- name: 'Configure hammer_cli_virt_who_configure'
-  command: cp ~/hammer-cli-foreman-virt-who-configure/config/foreman_virt_who_configure.yml ~/.hammer/cli.modules.d/
-  args:
-    creates: ~/.hammer/cli.modules.d/foreman_virt_who_configure.yml
-  when: ('theforeman/hammer-cli-foreman-virt-who-configure' in hammer_devel_repositories)
-
 - name: 'Alias hammer'
   lineinfile:
     dest: '~/.bash_profile'

--- a/roles/luna_provisioning/defaults/main.yml
+++ b/roles/luna_provisioning/defaults/main.yml
@@ -5,7 +5,6 @@ luna_provisioning_installer_internal_options:
   - "--enable-foreman-cli-remote-execution"
   - "--enable-foreman-cli-tasks"
   - "--enable-foreman-cli-templates"
-  - "--enable-foreman-cli-virt-who-configure"
   - "--enable-foreman-plugin-ansible"
   - "--enable-foreman-plugin-bootdisk"
   - "--enable-foreman-plugin-discovery"


### PR DESCRIPTION
As part of the containerization effort, we are dropping hammer-cli-virt-who, this is one of many pr's to drop it from all the places.