### PR TITLE
Fix puppet gem conflict when installing puppet-strings

### DIFF
--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -56,6 +56,7 @@
   gem:
     name: puppet-strings
     executable: /opt/puppetlabs/puppet/bin/gem
+    user_install: false
 
 - name: 'Install puppet/rhsm puppet module'
   command: "/opt/puppetlabs/bin/puppet module install puppet-rhsm --target-dir {{ foreman_installer_devel_scenario_modules }}"


### PR DESCRIPTION
puppet-strings 5.0.0 (released 2025-06-09) added puppet >= 8.0.0 as a runtime dependency. The Ansible gem module defaults user_install to true, so `gem install puppet-strings` now pulls the puppet gem into /root/.local/share/gem/, creating a second puppet installation alongside the puppet-agent package at /opt/puppetlabs/. When /opt/puppetlabs/bin/puppet runs, Ruby loads both, hitting a "superclass mismatch for class Uniquefile" fatal error that breaks all subsequent puppet commands in the playbook.

Setting user_install: false installs into the puppetlabs gem path (/opt/puppetlabs/puppet/lib/ruby/gems/) where the bundled puppet already satisfies the dependency, avoiding the duplicate.

## Error
```bash
  TASK [foreman_installer_devel_scenario : Install puppet/rhsm puppet module]
  fatal: [localhost]: FAILED! =>
      changed: true
      cmd:
      - /opt/puppetlabs/bin/puppet
      - module
      - install
      - puppet-rhsm
      - --target-dir
      - /usr/share/foreman-installer/modules
      msg: non-zero return code
      rc: 1
      stderr: |-
          /root/.local/share/gem/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/file_system/uniquefile.rb:13:in <top (required)>': Could not autoload 
  puppet/indirector/file_metadata/selector: superclass mismatch for class Uniquefile (Puppet::Error)         
  /root/.local/share/gem/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/file_system/uniquefile.rb:13:in <top (required)>': superclass mismatch for class Uniquefile
  (TypeError)
```

  The root cause is two conflicting puppet installations on the load path:
  - **Package**: `/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/` (puppet-agent RPM)
  - **Gem**: `/root/.local/share/gem/ruby/3.2.0/gems/puppet-8.10.0/` (pulled in as a dependency of puppet-strings 5.0.0)

