### PR TITLE
Fix facter binary conflict when installing puppet-strings

### DIFF
--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -57,6 +57,7 @@
     name: puppet-strings
     executable: /opt/puppetlabs/puppet/bin/gem
     user_install: false
+    force: true
 
 - name: 'Install puppet/rhsm puppet module'
   command: "/opt/puppetlabs/bin/puppet module install puppet-rhsm --target-dir {{ foreman_installer_devel_scenario_modules }}"


### PR DESCRIPTION
@ehelms last one, should have put this one into the one yesterday

The previous fix (user_install: false) correctly moved the puppet-strings gem install into the puppetlabs gem path to avoid a load path conflict. However, puppet-strings 5.0.0 depends on puppet, which depends on facter, and the facter gem tries to install a binary to /opt/puppetlabs/puppet/bin/facter that already exists from the puppet-agent package.

Adding force: true allows gem to overwrite the conflicting binary. This is safe because the facter gem and puppet-agent's facter are compatible.

Error after my first pr:
```bash
  TASK [foreman_installer_devel_scenario : Install gems to rebuild the kafo
    module cache] ***
  - "\e[0;31mfatal: [localhost]: FAILED! => \e[0m"
  - "\e[0;31m    changed: false\e[0m"
  - "\e[0;31m    cmd: /opt/puppetlabs/puppet/bin/gem install --norc --no-user-install --no-document\e[0m"
  - "\e[0;31m        puppet-strings\e[0m"
  - "\e[0;31m    msg: |-\e[0m"
  - "\e[0;31m        ERROR:  Error installing puppet-strings:\e[0m"
  - "\e[0;31m                \"facter\" from facter conflicts with /opt/puppetlabs/puppet/bin/facter\e[0m"
  - "\e[0;31m    rc: 1\e[0m"
  - "\e[0;31m    stderr: |-\e[0m"
  - "\e[0;31m        ERROR:  Error installing puppet-strings:\e[0m"
  - "\e[0;31m                \"facter\" from facter conflicts with /opt/puppetlabs/puppet/bin/facter\e[0m"
  - "\e[0;31m    stderr_lines: <omitted>\e[0m"
  - "\e[0;31m    stdout: |-\e[0m"
  - "\e[0;31m        Successfully installed yard-0.9.44\e[0m"
  - "\e[0;31m        Successfully installed rgen-0.10.2\e[0m"
  - "\e[0;31m        Successfully installed thor-1.2.2\e[0m"
  - "\e[0;31m    stdout_lines: <omitted>\e[0m"
  - ''
```

Proof it works now with this one:
```bash
broker checkout --workflow deploy-forklift-devel
18Jun 10:21:44 INFO     Using provider AnsibleTower to checkout
18Jun 10:21:45 INFO     No inventory specified, Ansible Tower will use a default.
               INFO     Waiting for job:
                        API: https://aap.example.com.com/api/controller/v2/workflow_jobs/110/
                        UI: https://aap.example.com.com/execution/jobs/workflow/110/output
18Jun 10:46:19 INFO     Host: host.example.com

chrobert@MS7656:~$ broker checkout --workflow deploy-iop-devel --stage_username xxxx--stage_password xxx --description 'iop devel box'
18Jun 11:15:54 INFO     Using provider AnsibleTower to checkout
18Jun 11:15:56 INFO     No inventory specified, Ansible Tower will use a default.
               INFO     Waiting for job:
                        API: https://aap.example.com/api/controller/v2/workflow_jobs/161/
                        UI: https://aap.example.com/execution/jobs/workflow/161/output
18Jun 11:49:32 INFO     Host: host.example.com
```