### PR TITLE
Pass Java version to candlepin acceptance tests via facter

### DIFF
--- a/pipelines/candlepin/03-tests.yml
+++ b/pipelines/candlepin/03-tests.yml
@@ -15,3 +15,5 @@
         beaker_os: "{{ pipeline_os.replace('-stream', '') }}"
         beaker_environment:
           BEAKER_FACTER_CANDLEPIN_BASEURL: "https://stagingyum.theforeman.org/candlepin/{{ pipeline_version }}/el{{ ansible_facts['distribution_major_version'] }}/x86_64"
+          BEAKER_FACTER_CANDLEPIN_JAVA_PACKAGE: "{{ 'java-25-openjdk-headless' if pipeline_version is version('4.8', '>=') else 'java-17-openjdk-headless' }}"
+          BEAKER_FACTER_CANDLEPIN_JAVA_HOME: "{{ '/usr/lib/jvm/jre-25' if pipeline_version is version('4.8', '>=') else '/usr/lib/jvm/jre-17' }}"


### PR DESCRIPTION
## Summary
- Candlepin 4.8+ is compiled targeting Java 25, while older versions (4.6) use Java 17
- The candlepin RPM pipeline acceptance test was failing because puppet-candlepin's example manifest hardcoded Java 17, which can't load Java 25 class files
- This passes `BEAKER_FACTER_CANDLEPIN_JAVA_PACKAGE` and `BEAKER_FACTER_CANDLEPIN_JAVA_HOME` so the puppet module uses the correct Java for each version

## Changes
- Added version-conditional facter variables to `pipelines/candlepin/03-tests.yml`
- `pipeline_version >= 4.8` → `java-25-openjdk-headless` / `/usr/lib/jvm/jre-25`
- Older versions → `java-17-openjdk-headless` / `/usr/lib/jvm/jre-17`

## Companion PR
- theforeman/puppet-candlepin#283 — updates the example manifest to read these facter variables

## Test plan
- [x] Reproduced the CI failure (`foreman-pipeline-candlepin-rpm-4.8`) locally in a container
- [x] Root cause confirmed: `UnsupportedClassVersionError: class file version 69.0` when Tomcat runs under Java 17 with Java 25 compiled classes
- [x] Verified the fix end-to-end: fresh AlmaLinux 9 container, puppet-apply with Java 25 facter vars → HTTP 200 on `/candlepin/status`, all acceptance test assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)