### PR TITLE
Switch from puppet-strings to openvox-strings

### DIFF
--- a/roles/foreman_installer/tasks/module_prs.yml
+++ b/roles/foreman_installer/tasks/module_prs.yml
@@ -9,7 +9,7 @@
     name: "{{ item }}"
     executable: /opt/puppetlabs/puppet/bin/gem
   with_items:
-    - puppet-strings
+    - openvox-strings
   when: puppetlabs_gem.stat.exists
   tags:
     - packages

--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -47,14 +47,14 @@
     update: yes
     version: "{{ katello_devel_branch }}"
 
-- name: 'Install puppet-agent'
+- name: 'Install openvox-agent'
   package:
-    name: puppet-agent
+    name: openvox-agent
     state: present
 
 - name: "Install gems to rebuild the kafo module cache"
   gem:
-    name: puppet-strings
+    name: openvox-strings
     executable: /opt/puppetlabs/puppet/bin/gem
     user_install: false
 


### PR DESCRIPTION
## Summary
- Replaces `puppet-strings` gem with `openvox-strings` (the Vox Pupuli successor) in both installer roles
- Switches `puppet-agent` package to `openvox-agent` in the devel scenario role
- `/opt/puppetlabs` paths are unchanged — OpenVox uses the same directory layout by design

Follows up on #1951 (006c52bb) which switched forklift to use OpenVox by default.

## Test plan
- [X] Verify `openvox-agent` package installs correctly from OpenVox repos
- [X] Verify `openvox-strings` gem installs via `/opt/puppetlabs/puppet/bin/gem`
- [X] Verify kafo module cache rebuild works with openvox-strings
- [X] Test module PR workflow (foreman_installer role)

Tested and was able to deploy a devel box:
```bash
broker checkout --workflow deploy-forklift-devel
06Jul 16:40:20 INFO     Using provider AnsibleTower to checkout
06Jul 16:40:21 INFO     No inventory specified, Ansible Tower will use a default.
06Jul 16:40:22 INFO     Waiting for job:
                        API: https://aap.example.com/api/controller/v2/workflow_jobs/54/
                        UI: https://aap.example.com/execution/jobs/workflow/54/output
06Jul 17:05:17 INFO     Host: host.example.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)