### PR TITLE
Workaround broken openssl 3.5.7-1 on EL9

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -13,3 +13,24 @@
   shell: rm -f /boot/*-generic.img
   when:
     - ansible_facts['os_family'] == 'Debian'
+
+# workaround for https://issues.redhat.com/browse/RHEL-192424
+- name: don't install broken openssl on EL9
+  community.general.ini_file:
+    path: /etc/dnf/dnf.conf
+    section: main
+    option: excludepkgs
+    value: 'openssl-3.5.7-1.*,openssl-libs-3.5.7-1.*,openssl-fips-provider-3.5.7-1.*'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] == '9'
+
+- name: force downgrade to openssl-3.5.5-3.el9
+  ansible.builtin.package:
+    name:
+      - openssl-3.5.5-3.el9
+      - openssl-libs-3.5.5-3.el9
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] == '9'


### PR DESCRIPTION
## Summary
- `openssl-3.5.7-1.el9` has an ASN.1 regression: a clean EOF at an object boundary now raises `ASN1_R_NOT_ENOUGH_DATA` instead of succeeding. Breaks any TLS client relying on the old behavior (ansible `uri` module, dnf/rpm HTTPS fetches, etc.)
- Confirmed hitting foreman-nightly-rpm-pipeline (theforeman CI), reproduced on CentOS Stream 9
- Same fix shape as the prior libsemanage/RHEL-55414 workaround in this file: `excludepkgs` the broken NVR + force downgrade to last known-good build (`openssl-3.5.5-3.el9`, confirmed still present in current CentOS Stream 9 BaseOS repo)
- Keep this workaround until the upstream fix (openssl/openssl#31818) merges and ships in a CentOS Stream 9 release, then revert

## References
- https://issues.redhat.com/browse/RHEL-192424
- https://github.com/openssl/openssl/pull/31818