### PR TITLE
Include openssl-fips-provider in EL9 openssl downgrade

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -30,6 +30,7 @@
     name:
       - openssl-3.5.5-3.el9
       - openssl-libs-3.5.5-3.el9
+      - openssl-fips-provider-3.5.5-3.el9
     state: present
   when:
     - ansible_facts['os_family'] == 'RedHat'


### PR DESCRIPTION
The openssl 3.5.7-1 workaround from #1960 (57f417c) excludes `openssl-fips-provider-3.5.7-1` but does not downgrade it. When the box already has `openssl-fips-provider-3.5.7-1` installed, its dependency on `openssl-libs = 3.5.7-1` conflicts with the exclude, causing a depsolve failure.

Adds `openssl-fips-provider-3.5.5-3.el9` to the downgrade list so all three packages pin to the same known-good NVR.