### PR TITLE
Use dnf allow_downgrade for openssl EL9 workaround

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -15,23 +15,21 @@
     - ansible_facts['os_family'] == 'Debian'
 
 # workaround for https://issues.redhat.com/browse/RHEL-192424
+- name: force downgrade to openssl-3.5.5-3.el9
+  ansible.builtin.dnf:
+    name: openssl-3.5.5-3.el9
+    state: present
+    allow_downgrade: true
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] == '9'
+
 - name: don't install broken openssl on EL9
   community.general.ini_file:
     path: /etc/dnf/dnf.conf
     section: main
     option: excludepkgs
     value: 'openssl-3.5.7-1.*,openssl-libs-3.5.7-1.*,openssl-fips-provider-3.5.7-1.*'
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - ansible_facts['distribution_major_version'] == '9'
-
-- name: force downgrade to openssl-3.5.5-3.el9
-  ansible.builtin.package:
-    name:
-      - openssl-3.5.5-3.el9
-      - openssl-libs-3.5.5-3.el9
-      - openssl-fips-provider-3.5.5-3.el9
-    state: present
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - ansible_facts['distribution_major_version'] == '9'


### PR DESCRIPTION
ansible.builtin.package with state: present won't downgrade when a newer version is already installed. Switch to ansible.builtin.dnf with allow_downgrade: true so the pinned NVRs actually replace the broken 3.5.7-1 packages.