### PR TITLE
beaker: install openssl-devel for gem native ext builds

### DIFF
--- a/roles/beaker/tasks/main.yml
+++ b/roles/beaker/tasks/main.yml
@@ -42,6 +42,7 @@
       - redhat-rpm-config
       - libffi-devel
       - libyaml-devel
+      - openssl-devel
 
 - name: Clone puppet module
   ansible.builtin.git:


### PR DESCRIPTION
## Summary

`foreman-pipeline-candlepin-rpm-nightly` has been failing since 2026-07-13 in the `beaker : Bundle install` task on both almalinux9 and centos9-stream legs:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
current directory: /usr/local/share/gems/gems/openssl-4.0.2/ext/openssl
checking for pkg-config for openssl... not found
checking for openssl/ssl.h... no
*** extconf.rb failed ***
```

Root cause: `io-stream` released `0.13.2` on 2026-07-12, adding a new runtime dependency `openssl >= 3.3`. That's pulled in transitively via the async/socketry stack used by `voxpupuli-acceptance` (part of `puppet-candlepin`'s test `Gemfile`). Ruby 3.3's bundled default `openssl` gem is `3.2.2`, so bundler now has to compile an external `openssl` gem — which has always been doomed here since `roles/beaker/tasks/main.yml` never installed `openssl-devel`.

Fix: add `openssl-devel` to the "Install Ruby" package list.



## Test plan

- [x] Reproduced the exact failure live on a test host (unpatched role): `openssl-4.0.2` build fails with the same `extconf.rb` error.
- [x] Applied this patch on the same host, cleaned gem state, re-ran: `bundle install` completes, `openssl (4.0.2, default: 3.2.2)` installed successfully, `bundle check` reports dependencies satisfied.
- [ ] Next nightly `foreman-pipeline-candlepin-rpm-nightly` run passes end to end after merge.