### PR TITLE
Revert "Workaround broken openssl 3.5.7-1 on EL9"

### DIFF
--- a/roles/vagrant_workarounds/tasks/main.yml
+++ b/roles/vagrant_workarounds/tasks/main.yml
@@ -13,25 +13,3 @@
   shell: rm -f /boot/*-generic.img
   when:
     - ansible_facts['os_family'] == 'Debian'
-
-# workaround for https://issues.redhat.com/browse/RHEL-192424
-- name: force downgrade to openssl-3.5.5-3.el9
-  ansible.builtin.dnf:
-    name: openssl-3.5.5-3.el9
-    state: present
-    allow_downgrade: true
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - ansible_facts['distribution_major_version'] == '9'
-    - ansible_facts['distribution'] == 'CentOS'
-
-- name: don't install broken openssl on EL9
-  community.general.ini_file:
-    path: /etc/dnf/dnf.conf
-    section: main
-    option: excludepkgs
-    value: 'openssl-3.5.7-1.*,openssl-libs-3.5.7-1.*,openssl-fips-provider-3.5.7-1.*'
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - ansible_facts['distribution_major_version'] == '9'
-    - ansible_facts['distribution'] == 'CentOS'


### PR DESCRIPTION
Reverts #1962.

The openssl ASN1 fix (RHEL-192424) is now present in CentOS Stream 9
repos, so the workaround is no longer needed.