### PR TITLE
Add EL10 nightly box definitions

### DIFF
--- a/vagrant/boxes.d/00-almalinux.yaml
+++ b/vagrant/boxes.d/00-almalinux.yaml
@@ -13,3 +13,10 @@ boxes:
     scenarios:
       - foreman
       - katello
+  almalinux10:
+    box_name: 'almalinux/10'
+    disk_size: 40
+    pty: true
+    scenarios:
+      - foreman
+      - katello

--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -143,7 +143,9 @@ installers:
     pulpcore: 'nightly'
     puppet: 8
     boxes:
+      - 'almalinux10'
       - 'almalinux9'
+      - 'centos10-stream'
       - 'centos9-stream'
       - 'debian12'
       - 'ubuntu2204'


### PR DESCRIPTION
## Summary

- Add `almalinux10` box definition to `vagrant/boxes.d/00-almalinux.yaml` (`centos10-stream` already exists in `00-centos.yaml`)
- Add `almalinux10` and `centos10-stream` to the nightly entry in `vagrant/config/versions.yaml`

## When to merge

This should be merged **before** the companion **jenkins-jobs PR** (theforeman/jenkins-jobs#590) which adds el10 to the nightly pipeline test targets. The jenkins-jobs pipelines generate forklift box patterns like `pipe-foreman-*nightly-centos10-stream` and `pipe-katello-*nightly-almalinux10`, which need these box definitions to exist.

Both PRs should stay as drafts until foreman-packaging, pulpcore-packaging, and candlepin-packaging are updated to build packages for EL10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)