### PR TITLE
Fix env stat check

### DIFF
--- a/roles/customize_home/tasks/fix_env.yml
+++ b/roles/customize_home/tasks/fix_env.yml
@@ -8,4 +8,4 @@
     path: "{{ ansible_facts['user_dir'] }}/foreman/.env"
     regexp: '(.*)--public [a-zA-Z0-9-\.]*(.*)'
     replace: '\1--public {{ ansible_facts["fqdn"] }}\2'
-  when: stat_result
+  when: stat_result.stat.exists


### PR DESCRIPTION
Before this commit, the task 'Check that the .env exists' failed with:

TASK [customize_home : Ensure .env file contains current hostname] *************
[ERROR]: Task failed: Conditional result was "{'changed': False, 'stat': [...]" of type 'dict', which evaluates to True. Conditionals must have a boolean result.