### PR TITLE
Update nightly candlepin to 5.0

### DIFF
--- a/vagrant/config/versions.yaml
+++ b/vagrant/config/versions.yaml
@@ -139,7 +139,7 @@ installers:
 
   - foreman: 'nightly'
     katello: 'nightly'
-    candlepin: '4.8'
+    candlepin: '5.0'
     pulpcore: 'nightly'
     puppet: 8
     boxes:


### PR DESCRIPTION
## Summary
- Update candlepin version from 4.8 to 5.0 for nightly in `vagrant/config/versions.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)