### PR TITLE
Add libcap-devel to devel boxes

### DIFF
--- a/roles/foreman_installer_devel_scenario/tasks/main.yml
+++ b/roles/foreman_installer_devel_scenario/tasks/main.yml
@@ -4,6 +4,7 @@
     name:
       - git
       - libffi-devel
+      - libcap-devel
     state: present
 
 - name: 'Ensure /etc/foreman-installer'


### PR DESCRIPTION
Deploy iop-devel fails with

```
\e[0;31m            Using foreman_virt_who_configure 5.0.0 from source at `../foreman_virt_who_configure`\e[0m
\e[0;31m            Gem::Ext::BuildError: ERROR: Failed to build gem native extension.\e[0m
\e[0;31m                current directory:\e[0m
\e[0;31m            /home/vagrant/foreman/.vendor/ruby/3.0.0/gems/cap2-0.2.2/ext/cap2\e[0m
\e[0;31m            /usr/bin/ruby -I /usr/share/rubygems -r ./siteconf20260811-23013-qu1uqs.rb\e[0m
\e[0;31m            extconf.rb\e[0m
\e[0;31m            checking for sys/capability.h... no\e[0m
\e[0;31m              -----\e[0m
\e[0;31m              ERROR\e[0m
\e[0;31m              -----\e[0m
\e[0;31m              sys/capability.h is missing. You should install the libcap2 header files\e[0m
\e[0;31m                *** extconf.rb failed ***\e[0m
```

I expect other devel options to fail with the same problem.