### PR TITLE
Add macOS support to the vagrant role

### DIFF
--- a/roles/vagrant/defaults/main.yml
+++ b/roles/vagrant/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 vagrant_libvirt: true
+vagrant_qemu: true
 vagrant_scp: false

--- a/roles/vagrant/tasks/linux.yml
+++ b/roles/vagrant/tasks/linux.yml
@@ -1,0 +1,48 @@
+---
+- name: 'bootstrap Vagrant and libvirt (requires root)'
+  become: true
+  block:
+    - name: 'install pvalena/vagrant copr'
+      get_url:
+        url: https://copr.fedorainfracloud.org/coprs/pvalena/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/pvalena-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo
+        dest: /etc/yum.repos.d/pvalena-vagrant.repo
+
+    - name: 'install evgeni/vagrant copr'
+      get_url:
+        url: https://copr.fedorainfracloud.org/coprs/evgeni/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/evgeni-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo
+        dest: /etc/yum.repos.d/evgeni-vagrant.repo
+
+    - name: 'install vagrant'
+      package:
+        name: vagrant
+        state: present
+
+    - name: 'install vagrant-libvirt'
+      package:
+        name: vagrant-libvirt
+        state: present
+      when: vagrant_libvirt
+
+    - include_tasks: 'vagrant_scp.yml'
+      when: vagrant_scp
+
+    - name: 'enable and start libvirtd'
+      ansible.builtin.systemd:
+        name: libvirtd
+        state: started
+        enabled: true
+      when: vagrant_libvirt
+
+    - name: 'enable and start virtnetworkd'
+      ansible.builtin.systemd:
+        name: virtnetworkd
+        state: started
+        enabled: true
+      when: vagrant_libvirt
+
+    - name: 'add invoking user to the libvirt group'
+      ansible.builtin.user:
+        name: "{{ ansible_env.SUDO_USER | default(ansible_user_id) }}"
+        groups: libvirt
+        append: true
+      when: vagrant_libvirt

--- a/roles/vagrant/tasks/macos.yml
+++ b/roles/vagrant/tasks/macos.yml
@@ -1,0 +1,53 @@
+---
+- name: 'install vagrant cask'
+  community.general.homebrew_cask:
+    name: vagrant
+    state: present
+  when: vagrant_qemu
+
+- name: 'install qemu'
+  community.general.homebrew:
+    name: qemu
+    state: present
+  when: vagrant_qemu
+
+- name: 'check for vagrant-qemu plugin'
+  ansible.builtin.command:
+    cmd: vagrant plugin list
+  register: vagrant_plugin_list
+  changed_when: false
+  when: vagrant_qemu
+
+- name: 'install vagrant-qemu plugin'
+  ansible.builtin.command:
+    cmd: vagrant plugin install vagrant-qemu
+  when:
+    - vagrant_qemu
+    - "'vagrant-qemu' not in vagrant_plugin_list.stdout"
+
+# forklift's own Vagrantfile uses vagrant-hostmanager to resolve VM hostnames
+# on the host (see vagrant/lib/forklift/box_distributor.rb); foremanctl's
+# Vagrantfile follows the same pattern for its qemu/macOS path.
+- name: 'install vagrant-hostmanager plugin'
+  ansible.builtin.command:
+    cmd: vagrant plugin install vagrant-hostmanager
+  when:
+    - vagrant_qemu
+    - "'vagrant-hostmanager' not in vagrant_plugin_list.stdout"
+
+- name: 'install socket_vmnet'
+  community.general.homebrew:
+    name: socket_vmnet
+    state: present
+  when: vagrant_qemu
+
+# socket_vmnet's daemon holds the root vmnet.framework membership so that
+# `vagrant up` itself never needs sudo (unlike the plugin's other vmnet
+# backends, which do and leave root-owned state files behind).
+- name: 'start the socket_vmnet daemon'
+  become: true
+  ansible.builtin.command:
+    cmd: brew services start socket_vmnet
+  register: socket_vmnet_service_result
+  changed_when: "'Successfully started' in socket_vmnet_service_result.stdout"
+  when: vagrant_qemu

--- a/roles/vagrant/tasks/main.yml
+++ b/roles/vagrant/tasks/main.yml
@@ -1,24 +1,6 @@
 ---
-- name: 'install pvalena/vagrant copr'
-  get_url:
-    url: https://copr.fedorainfracloud.org/coprs/pvalena/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/pvalena-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo
-    dest: /etc/yum.repos.d/pvalena-vagrant.repo
+- include_tasks: linux.yml
+  when: ansible_facts['os_family'] == 'RedHat'
 
-- name: 'install evgeni/vagrant copr'
-  get_url:
-    url: https://copr.fedorainfracloud.org/coprs/evgeni/vagrant/repo/epel-{{ ansible_facts['distribution_major_version'] }}/evgeni-vagrant-epel-{{ ansible_facts['distribution_major_version'] }}.repo
-    dest: /etc/yum.repos.d/evgeni-vagrant.repo
-
-- name: 'install vagrant'
-  package:
-    name: vagrant
-    state: present
-
-- name: 'install vagrant-libvirt'
-  package:
-    name: vagrant-libvirt
-    state: present
-  when: vagrant_libvirt
-
-- include_tasks: 'vagrant_scp.yml'
-  when: vagrant_scp
+- include_tasks: macos.yml
+  when: ansible_facts['system'] == 'Darwin'


### PR DESCRIPTION
Needed for theforeman/foremanctl#685, which asks for a `forge bootstrap-vagrant` command to bootstrap Vagrant and a hypervisor provider instead of pointing people at docs/vagrant.md. Used by theforeman/foremanctl#757.

The vagrant role only ever handled Fedora/CentOS with libvirt. This adds a macOS path (Vagrant, qemu, socket_vmnet, and the vagrant-qemu/vagrant-hostmanager plugins, all through Homebrew), and finishes automating the Linux path too: enabling libvirtd/virtnetworkd and adding the user to the libvirt group were still manual steps from docs/vagrant.md before this.

Tested end to end deploying foremanctl's dev VM on an Apple Silicon Mac.