### PR TITLE
enable fips on EL10 by using grubby directly

### DIFF
--- a/playbooks/fips.yml
+++ b/playbooks/fips.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
   become: yes
-  gather_facts: no
+  gather_facts: yes
   roles:
     - fips

--- a/roles/fips/tasks/main.yml
+++ b/roles/fips/tasks/main.yml
@@ -1,13 +1,20 @@
 ---
-- when: not ansible_fips
+- when: not ansible_facts['fips']
   block:
     - name: Install FIPS package
       package:
         name: crypto-policies-scripts
         state: present
 
-    - name: enable fips mode
+    - name: enable fips mode using fips-mode-setup
       command: /usr/bin/fips-mode-setup --enable
+      when:
+        - ansible_facts['distribution_major_version'] | int < 10
+
+    - name: enable fips mode using grubby (unsupported)
+      shell: grubby --update-kernel=$(grubby --default-kernel) --args=fips=1
+      when:
+        - ansible_facts['distribution_major_version'] | int >= 10
 
     - name: reboot vm
       reboot:


### PR DESCRIPTION
this is not officially supported (fips-mode-setup was removed in EL10, you can only officially enable FIPS mode at installation time), but good enough for our testing