### PR TITLE
enable SSH pipelining and connection persistence

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,3 +12,7 @@ remote_user = vagrant
 host_key_checking = False
 force_color = 1
 remote_tmp = /tmp/ansible-$USER
+
+[ssh_connection]
+pipelining = True
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=180s


### PR DESCRIPTION
this should help against the occasional "Timeout (12s) waiting for privilege escalation prompt" on Debian 13 we've been seeing